### PR TITLE
build matching `bitcoin-31.0-aarch64-linux-gnu.tar.gz` tarball

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -75,3 +75,63 @@ jobs:
           echo "expected: $expected"
           echo "actual:   $actual"
           [ "$actual" = "$expected" ]
+
+  # The aarch64 release is cross-compiled on the same x86_64 runner (no qemu —
+  # the build only emits aarch64 ELFs, it never runs them). Kept as a separate
+  # job from the x86_64 build because it's a long, independent build (its own
+  # gcc 14 / glibc 2.31 / binutils 2.41 cross toolchain + Qt6 cross depends);
+  # running in parallel keeps either result visible without waiting on the
+  # other, and a failure points squarely at one architecture.
+  build-aarch64:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-25.11
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: cachix/cachix-action@v12
+        with:
+          name: 0xb10c-bitcoind-gunix
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      # bitcoind-aarch64.nix's postFixup gates all 10 aarch64 binaries and
+      # tarball.nix gates the archive sha256 against the upstream GUIX v31.0
+      # aarch64-linux-gnu release, so a successful build IS the reproducibility
+      # test. Building .#tarballAarch64 also builds .#bitcoindAarch64. The
+      # steps below re-assert the hashes externally for CI-log visibility.
+      - run: nix build .#bitcoindAarch64 -o result-bitcoind --print-build-logs
+      - run: nix build .#tarballAarch64 -o result-tarball --print-build-logs
+      - name: Verify all 10 aarch64 binaries match upstream GUIX v31.0
+        run: |
+          declare -A expected=(
+            [bin/bitcoin]=c793384c78c11b2125d0b68cc62b05fab7a96d6438f005f9e375f7d4a41bfe4c
+            [bin/bitcoin-cli]=25c2743efb90ccaccbaea9f481e0a0357310af04b04f78b2320c0cc65ce12bf6
+            [bin/bitcoind]=6f66822a44b4d4edd2a8ae1a11f63dd4db8d070e219c8eb54a3e2faa536409c2
+            [bin/bitcoin-tx]=b41284232c62323a890bb8ba3befba1e1c4d197155461766a19618a0aaccda87
+            [bin/bitcoin-util]=3a0daa1c1f840fc7f9ac18a29619aab071230ee5f9ef2690fd7f93f3b9003488
+            [bin/bitcoin-wallet]=b7c2bb47030c7fb7e652c70a68c4c012cdd2e3562396423fc6c9ef01e0b589ac
+            [bin/bitcoin-qt]=760c3de5ff9a54edfc6bf0c769df6dfe610aa9055d8ea0fa99edca4a62dc14d4
+            [libexec/bitcoin-node]=f213271f7cec156be3d155c3c1012f4c226e2b9216a40215355a190105d1fad5
+            [libexec/bitcoin-gui]=f85193a8b7f4323f612b92a5b7e19cda977f90bb9c26543d3f5277bf10c59291
+            [libexec/test_bitcoin]=940fd792624130b36c1aef4fb4fc61723e622635478e7301bf37827caac9f1c5
+          )
+          rc=0
+          for rel in "${!expected[@]}"; do
+            actual=$(sha256sum "result-bitcoind/$rel" | cut -d' ' -f1)
+            if [ "$actual" = "${expected[$rel]}" ]; then
+              echo "OK:   $rel"
+            else
+              echo "FAIL: $rel  expected ${expected[$rel]}  actual $actual"; rc=1
+            fi
+          done
+          exit $rc
+      - name: Verify bitcoin-31.0-aarch64-linux-gnu.tar.gz matches upstream GUIX v31.0
+        run: |
+          expected=4de1d568dedd48604f75132421bc0abeca432639589b49a3909c81db3a813112
+          actual=$(sha256sum result-tarball | cut -d' ' -f1)
+          echo "expected: $expected"
+          echo "actual:   $actual"
+          [ "$actual" = "$expected" ]

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -23,14 +23,14 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-25.11
           extra_nix_config: |
             experimental-features = nix-command flakes
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-      - uses: cachix/cachix-action@v12
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - uses: cachix/cachix-action@v17
         with:
           name: 0xb10c-bitcoind-gunix
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -86,14 +86,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-25.11
           extra_nix_config: |
             experimental-features = nix-command flakes
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-      - uses: cachix/cachix-action@v12
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - uses: cachix/cachix-action@v17
         with:
           name: 0xb10c-bitcoind-gunix
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,17 +34,24 @@ patched to upstream's values (the `.dbg` themselves aren't
 byte-reproducible — see "Task #2 finding"); the separate `-debug.tar.gz`
 is not assembled.
 
-## Status (2026-06-04): aarch64 bitcoind ALSO byte-matches (cross-compiled)
+## Status (2026-06-04): FULL aarch64 release ALSO byte-matches (cross-compiled)
 
 `nix build .#bitcoindAarch64` cross-compiles — on an x86_64 machine, no
-qemu — a `bitcoind` for `aarch64-linux-gnu` whose sha256 is identical to
-the upstream GUIX `bitcoin-31.0-aarch64-linux-gnu` release binary:
+qemu — all 10 binaries of the `bitcoin-31.0-aarch64-linux-gnu` release,
+and `nix build .#tarballAarch64` assembles the full `.tar.gz`, every one
+byte-identical to the upstream GUIX release:
 
 ```
-6f66822a44b4d4edd2a8ae1a11f63dd4db8d070e219c8eb54a3e2faa536409c2  bin/bitcoind
+c793384c…  bin/bitcoin            b4128423…  bin/bitcoin-tx
+25c2743e…  bin/bitcoin-cli        3a0daa1c…  bin/bitcoin-util
+6f66822a…  bin/bitcoind           b7c2bb47…  bin/bitcoin-wallet
+760c3de5…  bin/bitcoin-qt         f213271f…  libexec/bitcoin-node
+f85193a8…  libexec/bitcoin-gui    940fd792…  libexec/test_bitcoin
+4de1d568…  bitcoin-31.0-aarch64-linux-gnu.tar.gz
 ```
 
-A `postFixup` sha256 gate in `bitcoind-aarch64.nix` asserts it every build.
+A `postFixup` sha256 gate in `bitcoind-aarch64.nix` asserts all 10
+binaries every build; `tarballAarch64` asserts the archive sha256.
 
 What it took, beyond the depends/bitcoind cross-build plumbing (HOST=
 aarch64-linux-gnu, the aarch64 ELF interpreter `/lib/ld-linux-aarch64.so.1`,
@@ -95,13 +102,18 @@ then narrowed to 6 glibc static members → branch protection + hardening.
 The upstream aarch64 release + `-debug.tar.gz` are the reference (sha
 `6f66822a…` / debuglink CRC `0xe8e5e289`).
 
-### Not yet done for aarch64 (optional, mirrors x86_64)
+### Full aarch64 release (all 10 + tarball) — DONE
 
-Only `bitcoind` is built (spike: `BUILD_TESTS=OFF`, `NO_QT` depends). The
-other 9 release binaries (need `BUILD_TESTS=ON` + the Qt6 depends tree for
-aarch64) and the aarch64 `.tar.gz` are mechanical replication of the proven
-x86_64 pattern — the hard codegen gap is closed. Each shipped binary needs
-its own upstream `.gnu_debuglink` CRC (extract from the `-debug.tar.gz`).
+`dependsAarch64` builds the full Qt6 tree (`buildQt = true`);
+`bitcoind-aarch64.nix` builds all 10 binaries (BUILD_TESTS left ON, GUI
+auto-enabled by the Qt depends) with per-binary split-debug +
+`.gnu_debuglink` CRC patch (cross binutils 2.41) and a 10-hash gate;
+`tarballAarch64` assembles the `.tar.gz` (`tarball.nix` parameterized by
+`arch` + `expectedSha256`). `depends.nix` needed no aarch64 changes — it
+was already `hostTriple`-parameterized — but its sources now fall back to
+the `bitcoincore.org/depends-sources` mirror (several upstream X.org /
+savannah source URLs have since 404'd; the mirror keeps the exact
+tarballs, so outputs are unchanged).
 
 ## WIP (2026-06-03): issue #6 — remove workarounds (B) + full tarball (A)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,75 @@ patched to upstream's values (the `.dbg` themselves aren't
 byte-reproducible — see "Task #2 finding"); the separate `-debug.tar.gz`
 is not assembled.
 
+## Status (2026-06-04): aarch64 bitcoind ALSO byte-matches (cross-compiled)
+
+`nix build .#bitcoindAarch64` cross-compiles — on an x86_64 machine, no
+qemu — a `bitcoind` for `aarch64-linux-gnu` whose sha256 is identical to
+the upstream GUIX `bitcoin-31.0-aarch64-linux-gnu` release binary:
+
+```
+6f66822a44b4d4edd2a8ae1a11f63dd4db8d070e219c8eb54a3e2faa536409c2  bin/bitcoind
+```
+
+A `postFixup` sha256 gate in `bitcoind-aarch64.nix` asserts it every build.
+
+What it took, beyond the depends/bitcoind cross-build plumbing (HOST=
+aarch64-linux-gnu, the aarch64 ELF interpreter `/lib/ld-linux-aarch64.so.1`,
+unset-CC-for-depends / set-CC-for-cmake), was a GUIX-exact aarch64 **cross
+toolchain** in `default.nix`, the cross analog of the native one:
+
+1. **cross binutils 2.41** (`crossBinutils241`) — override the build-host
+   cross binutils (`pkgsCrossAarch64.stdenv.cc.bintools.bintools`, *not*
+   `binutils-unwrapped` which is the aarch64-native one) down to 2.41.
+2. **cross glibc 2.31** (`crossGlibc231`) — `pkgsCrossAarch64.glibc`
+   overridden to GUIX's 2.31 git source, with: the 2.31 porting fixes
+   (no nss seds, no C.UTF-8 locale gen); `hardeningDisable`
+   (zerocallusedregs etc.); `-momit-leaf-frame-pointer` (keep the non-leaf
+   FP — see below); and `-mbranch-protection=standard` (it's built with the
+   *stock* cross gcc, so this per-compile flag gives its static members the
+   PAC/BTI that `--enable-standard-branch-protection` would).
+3. **cross gcc 14.3.0** (`crossGuixGcc`) — `pkgsCrossAarch64.stdenv.cc.cc`
+   with GUIX's linux-base-gcc flags (`--enable-standard-branch-protection`
+   → aarch64 BTI/PAC, default-pie/ssp, initfini-array, host-bind-now,
+   disable nls/libsanitizer/…) + the gcc-ssa-generation patch, **rebuilt
+   against glibc 2.31 via `libcCross = crossGlibc231`** (the scoped cross
+   analog of native `stdenvForGccRebuild`; the cc-wrapper + bintools `libc`
+   also point at 2.31). `--enable-cet` is x86-only and omitted.
+
+### The decisive aarch64-specific gotcha: frame pointers
+
+x86_64's `bitcoind.nix`/glibc use `-fomit-frame-pointer` because x86_64
+gcc omits the frame pointer at `-O2` by default. **aarch64 gcc at `-O2`
+KEEPS the non-leaf frame pointer and only omits the leaf one.** Upstream
+relies on that `-O2` default. nixpkgs' cross cc-wrapper forces
+`-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer` (keep both), so the
+correct flag everywhere on aarch64 (bitcoind, depends, glibc) is **only
+`-momit-leaf-frame-pointer`** — keep non-leaf, omit leaf. Copying x86_64's
+`-fomit-frame-pointer` stripped `stp x29,x30 / add x29,sp / ldp` from
+every non-leaf function → the binary was ~66 KB of `.text` + ~35 KB of
+`.eh_frame` (CFI) *below* upstream. This single flag closed the bulk of
+the gap; the glibc CRT codegen fixes (#2 above) closed the last 6
+functions (`__libc_csu_init/fini`, `atexit`, the stat wrappers).
+
+### Methodology note (how the gap was localized)
+
+bloaty section-diff (ours stripped vs upstream) flagged `.text`/`.eh_frame`;
+a per-function `nm --print-size` diff (our unstripped binary vs upstream's
+**decompressed** `.dbg` — `objcopy --decompress-debug-sections`; bloaty
+rejects the `.dbg`: empty build-id + SHF_COMPRESSED) showed the deltas were
+small (32–136 B) and pervasive → a global codegen flag (frame pointers),
+then narrowed to 6 glibc static members → branch protection + hardening.
+The upstream aarch64 release + `-debug.tar.gz` are the reference (sha
+`6f66822a…` / debuglink CRC `0xe8e5e289`).
+
+### Not yet done for aarch64 (optional, mirrors x86_64)
+
+Only `bitcoind` is built (spike: `BUILD_TESTS=OFF`, `NO_QT` depends). The
+other 9 release binaries (need `BUILD_TESTS=ON` + the Qt6 depends tree for
+aarch64) and the aarch64 `.tar.gz` are mechanical replication of the proven
+x86_64 pattern — the hard codegen gap is closed. Each shipped binary needs
+its own upstream `.gnu_debuglink` CRC (extract from the `-debug.tar.gz`).
+
 ## WIP (2026-06-03): issue #6 — remove workarounds (B) + full tarball (A)
 
 Working issue #6. Local reference artifacts (all gitignored):

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # bitcoind-gunix
 
-A Nix flake that reproduces the official Bitcoin Core GUIX release for
-`x86_64-linux-gnu` with **byte-identical sha256**: all ten binaries **and**
-the full release archive.
+A Nix flake that reproduces the official Bitcoin Core GUIX release with
+**byte-identical sha256** — all ten binaries **and** the full release
+archive — for both `x86_64-linux-gnu` and `aarch64-linux-gnu`. The aarch64
+release is **cross-compiled on an x86_64 host** (no qemu).
 
 ## Status
 
@@ -18,6 +19,19 @@ dae69848…  bin/bitcoind           7d8382b8…  bin/bitcoin-wallet
 416e79bb…  libexec/bitcoin-gui    c7a2a906…  libexec/test_bitcoin
 
 d3e4c58a…  bitcoin-31.0-x86_64-linux-gnu.tar.gz
+```
+
+The same holds for the `aarch64-linux-gnu` release, cross-compiled on
+x86_64:
+
+```
+c793384c…  bin/bitcoin            b4128423…  bin/bitcoin-tx
+25c2743e…  bin/bitcoin-cli        3a0daa1c…  bin/bitcoin-util
+6f66822a…  bin/bitcoind           b7c2bb47…  bin/bitcoin-wallet
+760c3de5…  bin/bitcoin-qt         f213271f…  libexec/bitcoin-node
+f85193a8…  libexec/bitcoin-gui    940fd792…  libexec/test_bitcoin
+
+4de1d568…  bitcoin-31.0-aarch64-linux-gnu.tar.gz
 ```
 
 Each derivation's `postFixup` asserts these hashes and fails the build on
@@ -40,12 +54,18 @@ nix build .#bitcoind --print-build-logs
 nix build .#tarball --print-build-logs
 sha256sum result        # -> d3e4c58a…
 
+# The aarch64 release, cross-compiled on x86_64 (10 binaries + tarball):
+nix build .#bitcoindAarch64 --print-build-logs
+nix build .#tarballAarch64 --print-build-logs
+sha256sum result        # -> 4de1d568…
+
 # Just the depends tree:
 nix build .#depends
 ```
 
 The first build is long — it rebuilds the gcc 14 / glibc 2.31 toolchain
-and the full Qt6 depends tree. A binary cache makes repeat builds fast.
+and the full Qt6 depends tree (the aarch64 outputs use their own cross
+toolchain + cross depends). A binary cache makes repeat builds fast.
 
 If a build fails and you want to inspect intermediate state, add
 `--keep-failed`. The gates print `OK:`/`FAIL:` lines with the hashes.
@@ -69,17 +89,21 @@ remaining byte patch. See `CLAUDE.md` for the full rationale.
   glibc 2.31 by overriding 25.11's glibc down to 2.31 (GUIX's exact git
   source), compiled with 25.11's **gcc 14.3.0** — the same gcc version
   GUIX uses, so no post-install byte patching of glibc is needed.
-- `default.nix` — assembles the gcc 14 + glibc 2.31 toolchain. Downgrades
-  binutils to 2.41 (matching GUIX), applies the `gcc-ssa-generation` patch
-  and GUIX's `linux-base-gcc` configure flags.
+- `default.nix` — assembles the gcc 14 + glibc 2.31 toolchain (binutils
+  downgraded to 2.41, the `gcc-ssa-generation` patch, GUIX's
+  `linux-base-gcc` flags), and the matching **aarch64 cross toolchain**
+  (cross binutils 2.41 + cross gcc rebuilt against cross glibc 2.31 via
+  `libcCross`). Exposes both the x86_64 and aarch64 outputs.
 - `depends.nix` — builds Bitcoin Core's `depends/` tree (incl. the full
-  Qt6 GUI dependencies) with `HOST=x86_64-linux-gnu` (cross-compile mode,
-  matching GUIX).
-- `bitcoind.nix` — builds all of Bitcoin Core via CMake, then split-debug,
-  `.comment` rewrite, `.gnu_debuglink` CRC patch, and asserts all ten
-  binary hashes.
-- `tarball.nix` — assembles `bitcoin-31.0-x86_64-linux-gnu.tar.gz`
-  byte-identical to upstream and asserts its hash.
+  Qt6 GUI dependencies); parameterized by `hostTriple`, so it serves both
+  `x86_64-linux-gnu` and the `aarch64-linux-gnu` cross build (`HOST=` puts
+  depends in cross-compile mode, matching GUIX either way).
+- `bitcoind.nix` / `bitcoind-aarch64.nix` — build all of Bitcoin Core via
+  CMake, then split-debug, `.comment` rewrite, `.gnu_debuglink` CRC patch,
+  and assert all ten binary hashes. The aarch64 variant cross-compiles with
+  the aarch64 ELF interpreter and the cross binutils.
+- `tarball.nix` — assembles `bitcoin-31.0-<arch>-linux-gnu.tar.gz`
+  byte-identical to upstream and asserts its hash (parameterized by `arch`).
 - `patches/` — patch files applied via the .nix derivations.
 - `CLAUDE.md` — design notes and the reproducibility methodology playbook.
 

--- a/bitcoind-aarch64.nix
+++ b/bitcoind-aarch64.nix
@@ -1,9 +1,9 @@
-# aarch64 cross-compile SPIKE (work in progress): cross-build bitcoind for
-# aarch64-linux-gnu using the aarch64 depends tree, to measure how close we
-# get to the upstream aarch64 release before investing in the GUIX-exact
-# toolchain. Intentionally minimal — no split-debug, no .gnu_debuglink CRC
-# patch, no reproducibility gate, no GUI (depends is NO_QT). Once the gap
-# is understood this should fold into a parameterized bitcoind.nix.
+# Cross-build the full Bitcoin Core v31.0 aarch64-linux-gnu release (all 10
+# binaries, incl. the Qt GUI) on an x86_64 machine, byte-for-byte identical
+# to the upstream GUIX release. The aarch64 analog of bitcoind.nix; kept as a
+# separate file because the cross build differs structurally (cross compiler
+# via CC export, aarch64 ELF interpreter, cross binutils for split-debug,
+# aarch64 frame-pointer handling, per-binary CRCs/hashes).
 { gcc14Stdenv
 , fetchurl
 , pkg-config
@@ -11,8 +11,8 @@
 , version
 , url
 , sha256
-, depends # the aarch64 depends tree
-, crossInputs # aarch64 cross cc/bintools (provides aarch64-linux-gnu-gcc)
+, depends # the aarch64 depends tree (Qt included)
+, crossInputs # aarch64 cross cc/bintools (provides aarch64-linux-gnu-gcc/-objcopy/…)
 }:
 
 let
@@ -36,10 +36,15 @@ gcc14Stdenv.mkDerivation {
 
   nativeBuildInputs = [ pkg-config cmake ] ++ crossInputs;
 
+  # Match GUIX's CONFIGFLAGS (contrib/guix/libexec/build.sh), same as the
+  # x86_64 bitcoind.nix: leave BUILD_TESTS at its default ON (builds
+  # bitcoin-tx/-util/-wallet + test_bitcoin), skip bench/fuzz/gui-tests. The
+  # depends toolchain.cmake auto-enables BUILD_GUI + WITH_QRENCODE because the
+  # Qt depends are present, so bitcoin-qt / libexec/bitcoin-gui build too.
   cmakeBuildDir = "build";
   cmakeFlags = [
     "--toolchain=${depends}/toolchain.cmake"
-    "-DBUILD_TESTS=OFF" # spike: just bitcoind, for speed
+    "-DBUILD_GUI_TESTS=OFF"
     "-DBUILD_BENCH=OFF"
     "-DBUILD_FUZZ_BINARY=OFF"
     "-DWITH_CCACHE=OFF"
@@ -51,8 +56,7 @@ gcc14Stdenv.mkDerivation {
     # nixpkgs' cmake setup-hook passes -DCMAKE_C_COMPILER=$CC etc., which
     # override the depends toolchain.cmake. Point CC/CXX at the aarch64
     # cross compiler so cmake cross-compiles (the native build stdenv would
-    # otherwise leave CC=gcc → native x86_64). AR/RANLIB/STRIP from the
-    # native binutils are multi-target and handle aarch64 objects fine.
+    # otherwise leave CC=gcc → native x86_64).
     export CC=aarch64-linux-gnu-gcc
     export CXX=aarch64-linux-gnu-g++
 
@@ -82,36 +86,72 @@ gcc14Stdenv.mkDerivation {
   # Mirror GUIX build.sh's split-debug + .gnu_debuglink handling (same as
   # x86_64 bitcoind.nix). Use the CROSS binutils 2.41 (aarch64-linux-gnu-*
   # from crossInputs) — not nixpkgs' native 2.44 — so strip/objcopy behave
-  # like upstream's. The .gnu_debuglink CRC is CRC32 of our bitcoind.dbg,
-  # which isn't byte-reproducible (DWARF path/triple divergence, see
-  # CLAUDE.md Task #2), so we overwrite it with upstream's value.
+  # like upstream's. The .gnu_debuglink CRC is CRC32 of each .dbg, which
+  # isn't byte-reproducible (DWARF path/triple divergence, see CLAUDE.md
+  # Task #2), so we overwrite it with upstream's per-binary value.
   postInstall = ''
     printf 'GCC: (GNU) 14.3.0\0' > comment.bin
-    f="$out/bin/bitcoind"
-    aarch64-linux-gnu-objcopy --enable-deterministic-archives -p --only-keep-debug "$f" "$f.dbg"
-    aarch64-linux-gnu-objcopy --enable-deterministic-archives -p --strip-debug "$f" "$f"
-    aarch64-linux-gnu-strip --enable-deterministic-archives -p -s "$f"
-    aarch64-linux-gnu-objcopy --enable-deterministic-archives -p --add-gnu-debuglink="$f.dbg" "$f"
-    aarch64-linux-gnu-objcopy --update-section .comment=comment.bin "$f"
-
-    # Overwrite the 4-byte CRC at the end of .gnu_debuglink with upstream's
-    # (0xe8e5e289 → little-endian 89 e2 e5 e8).
-    read -r doff dsize < <(aarch64-linux-gnu-readelf -SW "$f" | sed 's/\[[ 0-9]*\]//' \
-      | awk '/\.gnu_debuglink/{print strtonum("0x"$4), strtonum("0x"$5)}')
-    printf '\x89\xe2\xe5\xe8' | dd of="$f" bs=1 seek=$((doff + dsize - 4)) count=4 conv=notrunc status=none
+    for rel in \
+      bin/bitcoin bin/bitcoin-cli bin/bitcoind bin/bitcoin-tx \
+      bin/bitcoin-util bin/bitcoin-wallet bin/bitcoin-qt \
+      libexec/bitcoin-node libexec/bitcoin-gui libexec/test_bitcoin; do
+      f="$out/$rel"
+      if [ ! -f "$f" ]; then echo "WARN: $rel was not built"; continue; fi
+      aarch64-linux-gnu-objcopy --enable-deterministic-archives -p --only-keep-debug "$f" "$f.dbg"
+      aarch64-linux-gnu-objcopy --enable-deterministic-archives -p --strip-debug "$f" "$f"
+      aarch64-linux-gnu-strip --enable-deterministic-archives -p -s "$f"
+      aarch64-linux-gnu-objcopy --enable-deterministic-archives -p --add-gnu-debuglink="$f.dbg" "$f"
+      aarch64-linux-gnu-objcopy --update-section .comment=comment.bin "$f"
+      case "$(basename "$f")" in
+        bitcoin)        crc='\x95\x2c\x9d\xa9' ;;  # 0xa99d2c95
+        bitcoin-cli)    crc='\x6b\x5e\xd3\x3e' ;;  # 0x3ed35e6b
+        bitcoind)       crc='\x89\xe2\xe5\xe8' ;;  # 0xe8e5e289
+        bitcoin-tx)     crc='\x7f\x25\x4b\xa5' ;;  # 0xa54b257f
+        bitcoin-util)   crc='\x14\xdd\xda\xf5' ;;  # 0xf5dadd14
+        bitcoin-wallet) crc='\x01\xe9\x5e\x3f' ;;  # 0x3f5ee901
+        bitcoin-qt)     crc='\x64\xb1\xde\xe1' ;;  # 0xe1deb164
+        bitcoin-node)   crc='\x13\x70\xf1\x8b' ;;  # 0x8bf17013
+        bitcoin-gui)    crc='\xcf\x6b\xf1\xb3' ;;  # 0xb3f16bcf
+        test_bitcoin)   crc='\x2c\x63\x14\xe1' ;;  # 0xe114632c
+        *)              crc="" ;;
+      esac
+      if [ -n "$crc" ]; then
+        read -r doff dsize < <(aarch64-linux-gnu-readelf -SW "$f" | sed 's/\[[ 0-9]*\]//' \
+          | awk '/\.gnu_debuglink/{print strtonum("0x"$4), strtonum("0x"$5)}')
+        printf "$crc" | dd of="$f" bs=1 seek=$((doff + dsize - 4)) count=4 conv=notrunc status=none
+      fi
+    done
   '';
 
-  # Reproducibility gate: assert the cross-built aarch64 bitcoind byte-matches
-  # the upstream GUIX v31.0 release (bitcoin-31.0-aarch64-linux-gnu.tar.gz).
+  # Reproducibility gate: assert every shipped binary byte-matches the
+  # upstream GUIX v31.0 aarch64-linux-gnu release.
   postFixup = ''
-    expected=6f66822a44b4d4edd2a8ae1a11f63dd4db8d070e219c8eb54a3e2faa536409c2
-    actual=$(sha256sum "$out/bin/bitcoind" | cut -d' ' -f1)
-    if [ "$actual" = "$expected" ]; then
-      echo "OK: bitcoind-aarch64 matches upstream GUIX v31.0 ($expected)"
-    else
-      echo "FAIL: bitcoind-aarch64 expected $expected actual $actual"
-      exit 1
-    fi
+    declare -A expected=(
+      [bin/bitcoin]=c793384c78c11b2125d0b68cc62b05fab7a96d6438f005f9e375f7d4a41bfe4c
+      [bin/bitcoin-cli]=25c2743efb90ccaccbaea9f481e0a0357310af04b04f78b2320c0cc65ce12bf6
+      [bin/bitcoind]=6f66822a44b4d4edd2a8ae1a11f63dd4db8d070e219c8eb54a3e2faa536409c2
+      [bin/bitcoin-tx]=b41284232c62323a890bb8ba3befba1e1c4d197155461766a19618a0aaccda87
+      [bin/bitcoin-util]=3a0daa1c1f840fc7f9ac18a29619aab071230ee5f9ef2690fd7f93f3b9003488
+      [bin/bitcoin-wallet]=b7c2bb47030c7fb7e652c70a68c4c012cdd2e3562396423fc6c9ef01e0b589ac
+      [bin/bitcoin-qt]=760c3de5ff9a54edfc6bf0c769df6dfe610aa9055d8ea0fa99edca4a62dc14d4
+      [libexec/bitcoin-node]=f213271f7cec156be3d155c3c1012f4c226e2b9216a40215355a190105d1fad5
+      [libexec/bitcoin-gui]=f85193a8b7f4323f612b92a5b7e19cda977f90bb9c26543d3f5277bf10c59291
+      [libexec/test_bitcoin]=940fd792624130b36c1aef4fb4fc61723e622635478e7301bf37827caac9f1c5
+    )
+    fail=0
+    for rel in "''${!expected[@]}"; do
+      f="$out/$rel"
+      if [ ! -f "$f" ]; then echo "FAIL: $rel was not built"; fail=1; continue; fi
+      actual=$(sha256sum "$f" | cut -d' ' -f1)
+      if [ "$actual" = "''${expected[$rel]}" ]; then
+        echo "OK:   $rel matches upstream"
+      else
+        echo "FAIL: $rel  expected ''${expected[$rel]}  actual $actual"
+        fail=1
+      fi
+    done
+    [ "$fail" = "0" ] || { echo "FAIL: one or more aarch64 binaries diverged from upstream GUIX v31.0"; exit 1; }
+    echo "OK: all 10 aarch64 binaries match upstream GUIX v31.0"
   '';
 
   dontStrip = true;

--- a/bitcoind-aarch64.nix
+++ b/bitcoind-aarch64.nix
@@ -79,6 +79,41 @@ gcc14Stdenv.mkDerivation {
     "stackclashprotection" "fortify" "fortify3"
   ];
 
+  # Mirror GUIX build.sh's split-debug + .gnu_debuglink handling (same as
+  # x86_64 bitcoind.nix). Use the CROSS binutils 2.41 (aarch64-linux-gnu-*
+  # from crossInputs) — not nixpkgs' native 2.44 — so strip/objcopy behave
+  # like upstream's. The .gnu_debuglink CRC is CRC32 of our bitcoind.dbg,
+  # which isn't byte-reproducible (DWARF path/triple divergence, see
+  # CLAUDE.md Task #2), so we overwrite it with upstream's value.
+  postInstall = ''
+    printf 'GCC: (GNU) 14.3.0\0' > comment.bin
+    f="$out/bin/bitcoind"
+    aarch64-linux-gnu-objcopy --enable-deterministic-archives -p --only-keep-debug "$f" "$f.dbg"
+    aarch64-linux-gnu-objcopy --enable-deterministic-archives -p --strip-debug "$f" "$f"
+    aarch64-linux-gnu-strip --enable-deterministic-archives -p -s "$f"
+    aarch64-linux-gnu-objcopy --enable-deterministic-archives -p --add-gnu-debuglink="$f.dbg" "$f"
+    aarch64-linux-gnu-objcopy --update-section .comment=comment.bin "$f"
+
+    # Overwrite the 4-byte CRC at the end of .gnu_debuglink with upstream's
+    # (0xe8e5e289 → little-endian 89 e2 e5 e8).
+    read -r doff dsize < <(aarch64-linux-gnu-readelf -SW "$f" | sed 's/\[[ 0-9]*\]//' \
+      | awk '/\.gnu_debuglink/{print strtonum("0x"$4), strtonum("0x"$5)}')
+    printf '\x89\xe2\xe5\xe8' | dd of="$f" bs=1 seek=$((doff + dsize - 4)) count=4 conv=notrunc status=none
+  '';
+
+  # Reproducibility gate: assert the cross-built aarch64 bitcoind byte-matches
+  # the upstream GUIX v31.0 release (bitcoin-31.0-aarch64-linux-gnu.tar.gz).
+  postFixup = ''
+    expected=6f66822a44b4d4edd2a8ae1a11f63dd4db8d070e219c8eb54a3e2faa536409c2
+    actual=$(sha256sum "$out/bin/bitcoind" | cut -d' ' -f1)
+    if [ "$actual" = "$expected" ]; then
+      echo "OK: bitcoind-aarch64 matches upstream GUIX v31.0 ($expected)"
+    else
+      echo "FAIL: bitcoind-aarch64 expected $expected actual $actual"
+      exit 1
+    fi
+  '';
+
   dontStrip = true;
   doCheck = false;
   enableParallelBuilding = true;

--- a/bitcoind-aarch64.nix
+++ b/bitcoind-aarch64.nix
@@ -16,7 +16,15 @@
 }:
 
 let
-  cflags = "-O2 -g -fomit-frame-pointer -momit-leaf-frame-pointer"
+  # aarch64 frame pointers: upstream uses bare -O2, which on aarch64 KEEPS
+  # the non-leaf frame pointer but OMITS the leaf one. nixpkgs' cross
+  # cc-wrapper forces `-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer`
+  # (keep both). So we override only the leaf one back to omit — letting the
+  # wrapper's -fno-omit-frame-pointer keep the non-leaf FP, matching upstream.
+  # (On x86_64 the -O2 default omits both, hence bitcoind.nix uses
+  # -fomit-frame-pointer there; here we must NOT, or every non-leaf function
+  # loses its frame setup and the binary shrinks ~66 KB below upstream.)
+  cflags = "-O2 -g -momit-leaf-frame-pointer"
     + " -ffile-prefix-map=${depends}=/bitcoin/depends/aarch64-linux-gnu"
     + " -ffile-prefix-map=/build/bitcoin-${version}=/bitcoin"
     + " -ffile-prefix-map=/build/bitcoin-${version}/src=.";

--- a/bitcoind-aarch64.nix
+++ b/bitcoind-aarch64.nix
@@ -1,0 +1,77 @@
+# aarch64 cross-compile SPIKE (work in progress): cross-build bitcoind for
+# aarch64-linux-gnu using the aarch64 depends tree, to measure how close we
+# get to the upstream aarch64 release before investing in the GUIX-exact
+# toolchain. Intentionally minimal — no split-debug, no .gnu_debuglink CRC
+# patch, no reproducibility gate, no GUI (depends is NO_QT). Once the gap
+# is understood this should fold into a parameterized bitcoind.nix.
+{ gcc14Stdenv
+, fetchurl
+, pkg-config
+, cmake
+, version
+, url
+, sha256
+, depends # the aarch64 depends tree
+, crossInputs # aarch64 cross cc/bintools (provides aarch64-linux-gnu-gcc)
+}:
+
+let
+  cflags = "-O2 -g -fomit-frame-pointer -momit-leaf-frame-pointer"
+    + " -ffile-prefix-map=${depends}=/bitcoin/depends/aarch64-linux-gnu"
+    + " -ffile-prefix-map=/build/bitcoin-${version}=/bitcoin"
+    + " -ffile-prefix-map=/build/bitcoin-${version}/src=.";
+in
+gcc14Stdenv.mkDerivation {
+  pname = "bitcoind-aarch64";
+  name = "bitcoind-aarch64";
+  src = fetchurl { inherit url sha256; };
+
+  nativeBuildInputs = [ pkg-config cmake ] ++ crossInputs;
+
+  cmakeBuildDir = "build";
+  cmakeFlags = [
+    "--toolchain=${depends}/toolchain.cmake"
+    "-DBUILD_TESTS=OFF" # spike: just bitcoind, for speed
+    "-DBUILD_BENCH=OFF"
+    "-DBUILD_FUZZ_BINARY=OFF"
+    "-DWITH_CCACHE=OFF"
+    "-DREDUCE_EXPORTS=ON"
+    "-DCMAKE_SKIP_RPATH=TRUE"
+  ];
+
+  preConfigure = ''
+    # nixpkgs' cmake setup-hook passes -DCMAKE_C_COMPILER=$CC etc., which
+    # override the depends toolchain.cmake. Point CC/CXX at the aarch64
+    # cross compiler so cmake cross-compiles (the native build stdenv would
+    # otherwise leave CC=gcc → native x86_64). AR/RANLIB/STRIP from the
+    # native binutils are multi-target and handle aarch64 objects fine.
+    export CC=aarch64-linux-gnu-gcc
+    export CXX=aarch64-linux-gnu-g++
+
+    mkdir -p depends
+    # mpgen's baked capnp_PREFIX is .../depends/aarch64-linux-gnu.
+    ln -s ${depends} depends/aarch64-linux-gnu
+
+    # aarch64 ELF interpreter is /lib/ld-linux-aarch64.so.1 (vs the x86-64
+    # /lib64/ld-linux-x86-64.so.2). Mirrors GUIX's HOST_LDFLAGS.
+    cmakeFlagsArray+=(
+      "-DCMAKE_EXE_LINKER_FLAGS=-Wl,--as-needed -Wl,--dynamic-linker=/lib/ld-linux-aarch64.so.1 -Wl,-O2 -static-libstdc++ -static-libgcc"
+    )
+  '';
+
+  env = {
+    CFLAGS = cflags;
+    CXXFLAGS = cflags;
+    NIX_DONT_SET_RPATH = "1";
+    NIX_NO_SELF_RPATH = "1";
+  };
+
+  hardeningDisable = [
+    "zerocallusedregs" "strictoverflow" "stackprotector"
+    "stackclashprotection" "fortify" "fortify3"
+  ];
+
+  dontStrip = true;
+  doCheck = false;
+  enableParallelBuilding = true;
+}

--- a/default.nix
+++ b/default.nix
@@ -160,9 +160,32 @@ let
         "--disable-timezone-tools"
         "--disable-profile"
       ];
+    # aarch64 keeps the non-leaf frame pointer at -O2 (omit only the leaf
+    # one), unlike x86_64's glibc231 which omits both — see the frame-pointer
+    # note in bitcoind-aarch64.nix. Without this, glibc's libc_nonshared.a
+    # members (atexit, the stat wrappers) lose their frame setup and come out
+    # ~12 bytes smaller than upstream's.
+    #
+    # -mbranch-protection=standard: glibc is built with the *stock* cross
+    # gcc, which lacks GUIX's --enable-standard-branch-protection. The only
+    # glibc code that ends up *in* the binary is the statically-linked
+    # members (libc_nonshared.a's atexit/stat wrappers, csu's
+    # __libc_csu_init/fini), and without branch protection they miss the
+    # paciasp/autiasp (PAC) + bti landing pads upstream's glibc has — ~8
+    # bytes/function. This flag is exactly what --enable-standard-branch-
+    # protection defaults the compiler to, so it reproduces that codegen.
     env = (old.env or { }) // {
-      NIX_CFLAGS_COMPILE = "-fomit-frame-pointer";
+      NIX_CFLAGS_COMPILE = "-momit-leaf-frame-pointer -mbranch-protection=standard";
     };
+    # Disable the same nixpkgs hardenings flake.nix's x86_64 glibc231 drops.
+    # The decisive one is zerocallusedregs (-fzero-call-used-regs): it
+    # appends register-zeroing before `ret` in glibc's nonshared members
+    # (__libc_csu_init/fini), which upstream lacks — our csu objects were
+    # coming out ~28/8 bytes larger without this.
+    hardeningDisable = [
+      "zerocallusedregs" "strictoverflow" "stackprotector"
+      "stackclashprotection" "fortify" "fortify3"
+    ];
     postPatch = ''
       sed -i 's/ot \$/ot:\n\ttouch $@\n$/' manual/Makefile
       echo "LDFLAGS-nscd += -static-libgcc" >> nscd/Makefile

--- a/default.nix
+++ b/default.nix
@@ -130,6 +130,91 @@ let
     crossSystem = { config = "aarch64-linux-gnu"; };
   };
 
+  # aarch64 cross glibc 2.31 — the same overrides flake.nix applies to the
+  # native glibc231 (GUIX git source, no patches, GUIX configure flags,
+  # -fomit-frame-pointer, postPatch/postInstall fixes for 2.31), applied to
+  # the aarch64 cross glibc. Pointing the cross cc-wrapper's libc at this
+  # makes all cross compiles use glibc 2.31 headers/CRTs (vs nixpkgs 2.40)
+  # — the .text (inline functions) + dynsym/version gap driver.
+  # NOTE: --enable-cet is x86-only and omitted.
+  crossGlibc231 = pkgsCrossAarch64.glibc.overrideAttrs (old: {
+    version = "2.31";
+    src = pkgs.fetchgit {
+      name = "glibc-2.31";
+      url = "https://sourceware.org/git/glibc.git";
+      rev = "7b27c450c34563a28e634cccb399cd415e71ebfe";
+      hash = "sha256-wIq9cIHkI8HtsYa5UU1IfC8VIhXyz0vJau20WPJt+AQ=";
+    };
+    patches = [ ];
+    configureFlags =
+      (builtins.filter
+        (f: !(pkgs.lib.hasPrefix "--enable-kernel" f
+          || f == "--enable-stack-protector=strong"
+          || f == "--enable-cet=permissive"
+          || f == "--enable-fortify-source"))
+        (old.configureFlags or [ ]))
+      ++ [
+        "--enable-stack-protector=all"
+        "--enable-bind-now"
+        "--disable-werror"
+        "--disable-timezone-tools"
+        "--disable-profile"
+      ];
+    env = (old.env or { }) // {
+      NIX_CFLAGS_COMPILE = "-fomit-frame-pointer";
+    };
+    postPatch = ''
+      sed -i 's/ot \$/ot:\n\ttouch $@\n$/' manual/Makefile
+      echo "LDFLAGS-nscd += -static-libgcc" >> nscd/Makefile
+    '';
+    postInstall = ''
+      moveToOutput bin/getent $getent
+      test -f $out/etc/ld.so.cache && rm $out/etc/ld.so.cache
+      if test -n "$linuxHeaders"; then
+          (cd $dev/include && \
+           ln -sv $(ls -d $linuxHeaders/include/* | grep -v scsi\$) .)
+      fi
+      if test -n "$is64bit"; then
+          ln -s lib $out/lib64
+      fi
+      rm -rf $out/var $bin/bin/sln
+      ln -sf $out/lib/libpthread.so.0 $out/lib/libpthread.so
+      ln -sf $out/lib/librt.so.1 $out/lib/librt.so
+      ln -sf $out/lib/libdl.so.2 $out/lib/libdl.so
+      test -f $out/lib/libutil.so.1 && ln -sf $out/lib/libutil.so.1 $out/lib/libutil.so
+      touch $out/lib/libpthread.a
+      mkdir -p $static/lib
+      mv $out/lib/*.a $static/lib
+      mv $static/lib/lib*_nonshared.a $out/lib
+      test -f $out/lib/libutil.so.1 || mv $static/lib/libutil.a $out/lib
+      sed "/^GROUP/s|$out/lib/lib|$static/lib/lib|g" -i "$static"/lib/*.a
+      cp $bin/bin/getconf $bin/bin/getconf_
+      mv $bin/bin/getconf_ $bin/bin/getconf
+    '';
+  });
+
+  # Downgrade the aarch64 cross binutils to GUIX's 2.41 (nixpkgs cross
+  # ships 2.44; 2.44 relaxes aarch64 more aggressively → smaller
+  # .text/.eh_frame than upstream). Override the *build-host* cross
+  # binutils (the one that runs on x86_64 and targets aarch64) —
+  # `stdenv.cc.bintools.bintools`, NOT `binutils-unwrapped` (which is the
+  # aarch64-native binutils and can't run on the build machine). Mirrors
+  # default.nix's native binutilsForGuix.
+  crossBinutils241 = pkgsCrossAarch64.stdenv.cc.bintools.bintools.overrideAttrs (_: {
+    version = "2.41";
+    src = pkgs.fetchurl {
+      url = "mirror://gnu/binutils/binutils-2.41.tar.bz2";
+      sha256 = "sha256-pMS+wFL3uDcAJOYDieGUN38/SLVmGEGOpRBn9nqqsws=";
+    };
+    # Drop newer-binutils patches that may not apply to 2.41. Keep the
+    # default cross outputs (incl. `dev`) — unlike the native
+    # binutilsForGuix, the cross binutils' postInstall references $dev.
+    patches = [ ];
+  });
+  crossBintools241 = pkgsCrossAarch64.stdenv.cc.bintools.override {
+    bintools = crossBinutils241;
+  };
+
   # Full-attempt (gap-closing): rebuild the aarch64 cross gcc 14.3.0 with
   # GUIX's linux-base-gcc configure flags + the deterministic-SSA patch, so
   # ALL cross-compiled code (depends, glibc, bitcoind) gets GUIX's codegen
@@ -139,6 +224,7 @@ let
   # mirrors default.nix's native gcc rebuild, but for the cross compiler.
   # (--enable-cet is x86-only and omitted here.)
   crossGuixGcc = pkgsCrossAarch64.stdenv.cc.override {
+    bintools = crossBintools241;
     cc = pkgsCrossAarch64.stdenv.cc.cc.overrideAttrs (old: {
       configureFlags = (old.configureFlags or [ ]) ++ [
         "--enable-standard-branch-protection=yes"
@@ -168,8 +254,12 @@ let
   # Cross-build the depends tree (NO_QT for now) with a *native* build
   # stdenv (so the native helper tools — native_capnp, mpgen — use the
   # build machine's gcc) plus the aarch64 cross toolchain on PATH (so HOST
-  # packages use aarch64-linux-gnu-gcc). glibc is still nixpkgs' (2.40) —
-  # the cross glibc 2.31 + binutils 2.41 are the remaining gap pieces.
+  # packages use aarch64-linux-gnu-gcc). Uses the GUIX-flags cross gcc +
+  # binutils 2.41. glibc is still nixpkgs' 2.40: `crossGlibc231` (built &
+  # exposed as `.#crossGlibc231`) is ready, but wiring it via the
+  # cc-wrapper `libc` alone breaks linking (gcc/libgcc built against 2.40
+  # vs 2.31 startfiles) — it needs the cross gcc rebuilt against glibc 2.31
+  # (default.nix's stdenvForGccRebuild analog), the remaining gap piece.
   dependsAarch64 = pkgs.callPackage ./depends.nix {
     inherit version url sha256;
     inherit (pkgs) gcc14Stdenv;
@@ -184,5 +274,5 @@ let
     crossInputs = aarch64CrossInputs;
   };
 in {
-  inherit depends bitcoind tarball dependsAarch64 bitcoindAarch64;
+  inherit depends bitcoind tarball dependsAarch64 bitcoindAarch64 crossGlibc231;
 }

--- a/default.nix
+++ b/default.nix
@@ -213,6 +213,7 @@ let
   });
   crossBintools241 = pkgsCrossAarch64.stdenv.cc.bintools.override {
     bintools = crossBinutils241;
+    libc = crossGlibc231;
   };
 
   # Full-attempt (gap-closing): rebuild the aarch64 cross gcc 14.3.0 with
@@ -223,9 +224,21 @@ let
   # (upstream has ~40.4k BTI vs ~34.5k from the stock cross gcc). This
   # mirrors default.nix's native gcc rebuild, but for the cross compiler.
   # (--enable-cet is x86-only and omitted here.)
+  #
+  # `libcCross = crossGlibc231` rebuilds the cross gcc (and its libstdc++)
+  # *targeting* glibc 2.31 — the scoped analog of default.nix's
+  # stdenvForGccRebuild. Setting the cc-wrapper/bintools `libc` to 2.31
+  # alone broke linking (gcc/libgcc still built against 2.40 startfiles);
+  # rebuilding gcc against 2.31 fixes that coherently, without the overlay
+  # approach's breakage (overlaying glibc hit the x86_64 *build* glibc too).
+  # This closes the remaining gap: 2.31 headers (inline functions → .text /
+  # .eh_frame) + 2.31 dynsym/symbol versions.
   crossGuixGcc = pkgsCrossAarch64.stdenv.cc.override {
     bintools = crossBintools241;
-    cc = pkgsCrossAarch64.stdenv.cc.cc.overrideAttrs (old: {
+    libc = crossGlibc231;
+    cc = (pkgsCrossAarch64.stdenv.cc.cc.override {
+      libcCross = crossGlibc231;
+    }).overrideAttrs (old: {
       configureFlags = (old.configureFlags or [ ]) ++ [
         "--enable-standard-branch-protection=yes"
         "--enable-default-pie=yes"
@@ -255,11 +268,12 @@ let
   # stdenv (so the native helper tools — native_capnp, mpgen — use the
   # build machine's gcc) plus the aarch64 cross toolchain on PATH (so HOST
   # packages use aarch64-linux-gnu-gcc). Uses the GUIX-flags cross gcc +
-  # binutils 2.41. glibc is still nixpkgs' 2.40: `crossGlibc231` (built &
-  # exposed as `.#crossGlibc231`) is ready, but wiring it via the
-  # cc-wrapper `libc` alone breaks linking (gcc/libgcc built against 2.40
-  # vs 2.31 startfiles) — it needs the cross gcc rebuilt against glibc 2.31
-  # (default.nix's stdenvForGccRebuild analog), the remaining gap piece.
+  # binutils 2.41, rebuilt against glibc 2.31 (crossGlibc231 via libcCross
+  # above). With 2.31 the binary's dynsym GLIBC symbol versions match
+  # upstream exactly (325×2.17, 2×2.25, 2.27, 2.28, 4×2.29, 2.30; max 2.30)
+  # and ~35 KB of .text inline-function delta closed. Remaining gap vs the
+  # upstream aarch64 binary: .text ≈ -66 KB, .eh_frame ≈ -35 KB (codegen
+  # iteration, like the x86_64 effort).
   dependsAarch64 = pkgs.callPackage ./depends.nix {
     inherit version url sha256;
     inherit (pkgs) gcc14Stdenv;

--- a/default.nix
+++ b/default.nix
@@ -118,6 +118,44 @@ let
   tarball = pkgs.callPackage ./tarball.nix {
     inherit version url sha256 bitcoind;
   };
+
+  # --- aarch64 cross-compile spike (work in progress) ---
+  # nixpkgs instantiated to cross-compile x86_64 -> aarch64-linux-gnu. We
+  # use the GUIX target triple `aarch64-linux-gnu` (not nixpkgs' default
+  # `aarch64-unknown-linux-gnu`) so the cross compiler is named
+  # `aarch64-linux-gnu-gcc`, which is what Bitcoin's depends Makefile
+  # invokes for HOST packages.
+  pkgsCrossAarch64 = import pkgs.path {
+    localSystem = "x86_64-linux";
+    crossSystem = { config = "aarch64-linux-gnu"; };
+  };
+  # Spike: cross-build the depends tree (NO_QT for now) with a *native*
+  # build stdenv (so the native helper tools — native_capnp, mpgen — use
+  # the build machine's gcc) plus the aarch64 cross cc-wrapper on PATH
+  # (so HOST packages use aarch64-linux-gnu-gcc). Stock nixpkgs cross
+  # toolchain for now — not yet the GUIX-exact gcc-14.3.0/glibc-2.31.
+  dependsAarch64 = pkgs.callPackage ./depends.nix {
+    inherit version url sha256;
+    inherit (pkgs) gcc14Stdenv;
+    hostTriple = "aarch64-linux-gnu";
+    buildQt = false;
+    # The aarch64 cross cc-wrapper (provides aarch64-linux-gnu-gcc/g++ and
+    # the gcc-ar/-nm/-ranlib helpers) + its bintools (aarch64-linux-gnu-ar,
+    # -strip, -objcopy, …).
+    crossInputs = [
+      pkgsCrossAarch64.stdenv.cc
+      pkgsCrossAarch64.stdenv.cc.bintools
+    ];
+  };
+  bitcoindAarch64 = pkgs.callPackage ./bitcoind-aarch64.nix {
+    inherit version url sha256;
+    inherit (pkgs) gcc14Stdenv;
+    depends = dependsAarch64;
+    crossInputs = [
+      pkgsCrossAarch64.stdenv.cc
+      pkgsCrossAarch64.stdenv.cc.bintools
+    ];
+  };
 in {
-  inherit depends bitcoind tarball;
+  inherit depends bitcoind tarball dependsAarch64 bitcoindAarch64;
 }

--- a/default.nix
+++ b/default.nix
@@ -129,32 +129,59 @@ let
     localSystem = "x86_64-linux";
     crossSystem = { config = "aarch64-linux-gnu"; };
   };
-  # Spike: cross-build the depends tree (NO_QT for now) with a *native*
-  # build stdenv (so the native helper tools — native_capnp, mpgen — use
-  # the build machine's gcc) plus the aarch64 cross cc-wrapper on PATH
-  # (so HOST packages use aarch64-linux-gnu-gcc). Stock nixpkgs cross
-  # toolchain for now — not yet the GUIX-exact gcc-14.3.0/glibc-2.31.
+
+  # Full-attempt (gap-closing): rebuild the aarch64 cross gcc 14.3.0 with
+  # GUIX's linux-base-gcc configure flags + the deterministic-SSA patch, so
+  # ALL cross-compiled code (depends, glibc, bitcoind) gets GUIX's codegen
+  # defaults — most importantly --enable-standard-branch-protection, which
+  # emits BTI landing pads + PAC return-signing on aarch64 everywhere
+  # (upstream has ~40.4k BTI vs ~34.5k from the stock cross gcc). This
+  # mirrors default.nix's native gcc rebuild, but for the cross compiler.
+  # (--enable-cet is x86-only and omitted here.)
+  crossGuixGcc = pkgsCrossAarch64.stdenv.cc.override {
+    cc = pkgsCrossAarch64.stdenv.cc.cc.overrideAttrs (old: {
+      configureFlags = (old.configureFlags or [ ]) ++ [
+        "--enable-standard-branch-protection=yes"
+        "--enable-default-pie=yes"
+        "--enable-default-ssp=yes"
+        "--enable-initfini-array=yes"
+        "--enable-host-bind-now=yes"
+        "--enable-gprofng=no"
+        "--disable-gcov"
+        "--disable-libgomp"
+        "--disable-libquadmath"
+        "--disable-libsanitizer"
+        "--disable-nls"
+      ];
+      patches = (old.patches or [ ]) ++ [ ./patches/gcc-ssa-generation.patch ];
+    });
+  };
+
+  # aarch64 cross toolchain inputs: the GUIX-flags cross gcc wrapper
+  # (provides aarch64-linux-gnu-gcc/g++ + gcc-ar/-nm/-ranlib) and its
+  # bintools (aarch64-linux-gnu-ar/-strip/-objcopy/…).
+  aarch64CrossInputs = [
+    crossGuixGcc
+    crossGuixGcc.bintools
+  ];
+
+  # Cross-build the depends tree (NO_QT for now) with a *native* build
+  # stdenv (so the native helper tools — native_capnp, mpgen — use the
+  # build machine's gcc) plus the aarch64 cross toolchain on PATH (so HOST
+  # packages use aarch64-linux-gnu-gcc). glibc is still nixpkgs' (2.40) —
+  # the cross glibc 2.31 + binutils 2.41 are the remaining gap pieces.
   dependsAarch64 = pkgs.callPackage ./depends.nix {
     inherit version url sha256;
     inherit (pkgs) gcc14Stdenv;
     hostTriple = "aarch64-linux-gnu";
     buildQt = false;
-    # The aarch64 cross cc-wrapper (provides aarch64-linux-gnu-gcc/g++ and
-    # the gcc-ar/-nm/-ranlib helpers) + its bintools (aarch64-linux-gnu-ar,
-    # -strip, -objcopy, …).
-    crossInputs = [
-      pkgsCrossAarch64.stdenv.cc
-      pkgsCrossAarch64.stdenv.cc.bintools
-    ];
+    crossInputs = aarch64CrossInputs;
   };
   bitcoindAarch64 = pkgs.callPackage ./bitcoind-aarch64.nix {
     inherit version url sha256;
     inherit (pkgs) gcc14Stdenv;
     depends = dependsAarch64;
-    crossInputs = [
-      pkgsCrossAarch64.stdenv.cc
-      pkgsCrossAarch64.stdenv.cc.bintools
-    ];
+    crossInputs = aarch64CrossInputs;
   };
 in {
   inherit depends bitcoind tarball dependsAarch64 bitcoindAarch64;

--- a/default.nix
+++ b/default.nix
@@ -287,21 +287,19 @@ let
     crossGuixGcc.bintools
   ];
 
-  # Cross-build the depends tree (NO_QT for now) with a *native* build
-  # stdenv (so the native helper tools — native_capnp, mpgen — use the
-  # build machine's gcc) plus the aarch64 cross toolchain on PATH (so HOST
-  # packages use aarch64-linux-gnu-gcc). Uses the GUIX-flags cross gcc +
-  # binutils 2.41, rebuilt against glibc 2.31 (crossGlibc231 via libcCross
-  # above). With 2.31 the binary's dynsym GLIBC symbol versions match
-  # upstream exactly (325×2.17, 2×2.25, 2.27, 2.28, 4×2.29, 2.30; max 2.30)
-  # and ~35 KB of .text inline-function delta closed. Remaining gap vs the
-  # upstream aarch64 binary: .text ≈ -66 KB, .eh_frame ≈ -35 KB (codegen
-  # iteration, like the x86_64 effort).
+  # Cross-build the full depends tree (incl. the Qt6 GUI tree) with a *native*
+  # build stdenv (so the native helper tools — native_capnp, mpgen, native_qt
+  # — use the build machine's gcc) plus the aarch64 cross toolchain on PATH
+  # (so HOST packages use aarch64-linux-gnu-gcc). Uses the GUIX-flags cross
+  # gcc + binutils 2.41, rebuilt against glibc 2.31 (crossGlibc231 via
+  # libcCross above) — which makes all 10 cross-built binaries byte-match the
+  # upstream aarch64 release (the dynsym GLIBC symbol versions, .text/.eh_frame
+  # all line up; see CLAUDE.md's aarch64 section).
   dependsAarch64 = pkgs.callPackage ./depends.nix {
     inherit version url sha256;
     inherit (pkgs) gcc14Stdenv;
     hostTriple = "aarch64-linux-gnu";
-    buildQt = false;
+    buildQt = true;
     crossInputs = aarch64CrossInputs;
   };
   bitcoindAarch64 = pkgs.callPackage ./bitcoind-aarch64.nix {
@@ -310,6 +308,12 @@ let
     depends = dependsAarch64;
     crossInputs = aarch64CrossInputs;
   };
+  tarballAarch64 = pkgs.callPackage ./tarball.nix {
+    inherit version url sha256;
+    bitcoind = bitcoindAarch64;
+    arch = "aarch64-linux-gnu";
+    expectedSha256 = "4de1d568dedd48604f75132421bc0abeca432639589b49a3909c81db3a813112";
+  };
 in {
-  inherit depends bitcoind tarball dependsAarch64 bitcoindAarch64 crossGlibc231;
+  inherit depends bitcoind tarball dependsAarch64 bitcoindAarch64 tarballAarch64 crossGlibc231;
 }

--- a/depends.nix
+++ b/depends.nix
@@ -322,7 +322,14 @@ gcc14Stdenv.mkDerivation (rec {
   # `v31-guix-build.log` line 18550 for sqlite). It just changes IPC
   # between gcc stages from temp files to pipes — shouldn't affect
   # codegen, but included for compile-command parity.
-  env.NIX_CFLAGS_COMPILE = "-fomit-frame-pointer -momit-leaf-frame-pointer -pipe";
+  # aarch64 keeps the non-leaf frame pointer at -O2 (unlike x86_64, which
+  # omits it). So for aarch64 we only omit the LEAF frame pointer and let
+  # the wrapper's -fno-omit-frame-pointer keep the non-leaf one — matching
+  # upstream's bare -O2. x86_64 omits both (its -O2 default). See the
+  # frame-pointer note in bitcoind-aarch64.nix.
+  env.NIX_CFLAGS_COMPILE =
+    (if lib.hasPrefix "aarch64" hostTriple then "" else "-fomit-frame-pointer ")
+    + "-momit-leaf-frame-pointer -pipe";
 
   # Disable nixpkgs hardenings that GUIX's toolchain doesn't apply to
   # depends compiles:

--- a/depends.nix
+++ b/depends.nix
@@ -37,9 +37,20 @@ let
   # `downloadFile` is the name on the remote server (defaults to `file`). It
   # only differs from `file` when the upstream depends Makefile renames the
   # tarball locally (e.g. capnp's `capnproto-c++` -> `capnproto-cxx`).
+  #
+  # Each source falls back to https://bitcoincore.org/depends-sources/ —
+  # Bitcoin Core's canonical depends-source mirror (the depends Makefile's own
+  # FALLBACK_DOWNLOAD_PATH). Several upstream hosts have since moved or 404'd
+  # (xorg.freedesktop.org reorganized its proto/lib archives, savannah's
+  # freetype mirror flakes), so the primary URL alone is no longer reliable;
+  # the mirror keeps the exact tarballs (same sha256), making the build
+  # reproducible regardless of upstream churn.
   mkFetchSource = {urlPrefix, file, sha256, downloadFile ? file}:
     fetchurl {
-      url = "${urlPrefix}/${downloadFile}";
+      urls = [
+        "${urlPrefix}/${downloadFile}"
+        "https://bitcoincore.org/depends-sources/${downloadFile}"
+      ];
       inherit sha256;
     };
 

--- a/depends.nix
+++ b/depends.nix
@@ -16,6 +16,19 @@
 , version
 , url
 , sha256
+# Target triple for the depends build. Native x86_64 by default; set to
+# e.g. "aarch64-linux-gnu" to cross-compile (depends then uses
+# <hostTriple>-gcc, which crossInputs must provide on PATH).
+, hostTriple ? "x86_64-linux-gnu"
+# Build the Qt GUI dependency tree. Disabled for the aarch64 spike.
+, buildQt ? true
+# Extra nativeBuildInputs providing the `<hostTriple>-gcc`/`-ar`/… cross
+# toolchain when cross-compiling (empty for a native build). When
+# non-empty, the build also unsets the Nix-exported CC/CXX/… so Bitcoin's
+# depends derives the host_toolchain-prefixed cross tools instead of the
+# native `gcc` (hosts/default.mk add_host_tool_func treats an
+# environment-set CC as the host compiler).
+, crossInputs ? [ ]
 }:
 
 let
@@ -189,7 +202,7 @@ let
     ) dependsSources;
 
 in
-gcc14Stdenv.mkDerivation rec {
+gcc14Stdenv.mkDerivation (rec {
   name = "bitcoin-${version}-depends";
   pname = "bitcoin-depends";
 
@@ -229,7 +242,7 @@ gcc14Stdenv.mkDerivation rec {
     sed -i 's|^  \$(package)_cflags += -Wno-implicit-function-declaration$|&\n  $(package)_cflags += -I$(host_prefix)/include/freetype2|' \
       ${dependsDir}/packages/fontconfig.mk
 
-    # Match GUIX's depends prefix (/bitcoin/depends/x86_64-linux-gnu) in
+    # Match GUIX's depends prefix (/bitcoin/depends/${hostTriple}) in
     # the runtime paths that Qt and libxkbcommon bake into their static
     # libs (and that get linked into bitcoin-qt / bitcoin-gui): Qt's
     # qt_prfxpath + icon search dirs, and libxkbcommon's xkb config root.
@@ -249,9 +262,9 @@ gcc14Stdenv.mkDerivation rec {
     # the *.cmake/*.pc files so the bitcoind build still finds Qt; the
     # baked runtime strings in the .a libraries keep the GUIX prefix,
     # matching upstream's bitcoin-qt / bitcoin-gui.
-    sed -i 's|-prefix \$(host_prefix)$|-prefix /bitcoin/depends/x86_64-linux-gnu|' \
+    sed -i 's|-prefix \$(host_prefix)$|-prefix /bitcoin/depends/${hostTriple}|' \
       ${dependsDir}/packages/qt.mk
-    sed -i 's|^\$(package)_config_opts += --disable-shared --disable-docs$|&\n$(package)_config_opts += --with-xkb-config-root=/bitcoin/depends/x86_64-linux-gnu/share/X11/xkb|' \
+    sed -i 's|^\$(package)_config_opts += --disable-shared --disable-docs$|&\n$(package)_config_opts += --with-xkb-config-root=/bitcoin/depends/${hostTriple}/share/X11/xkb|' \
       ${dependsDir}/packages/libxkbcommon.mk
 
     # xcb-util-cursor bakes the XCURSOR theme search path from its datadir
@@ -259,7 +272,7 @@ gcc14Stdenv.mkDerivation rec {
     # libxcb-cursor.a, which is linked into bitcoin-qt / bitcoin-gui. Pin it
     # to GUIX's prefix via --with-cursorpath (independent of our build-time
     # datadir) so the baked string matches upstream.
-    sed -i 's|^\$(package)_config_opts += --disable-dependency-tracking --enable-option-checking$|&\n$(package)_config_opts += --with-cursorpath=~/.local/share/icons:~/.icons:/bitcoin/depends/x86_64-linux-gnu/share/icons:/bitcoin/depends/x86_64-linux-gnu/share/pixmaps|' \
+    sed -i 's|^\$(package)_config_opts += --disable-dependency-tracking --enable-option-checking$|&\n$(package)_config_opts += --with-cursorpath=~/.local/share/icons:~/.icons:/bitcoin/depends/${hostTriple}/share/icons:/bitcoin/depends/${hostTriple}/share/pixmaps|' \
       ${dependsDir}/packages/libxcb_util_cursor.mk
   '';
 
@@ -272,7 +285,11 @@ gcc14Stdenv.mkDerivation rec {
     ./patches/depends-funcs-test-source-exists.patch
   ];
 
-  nativeBuildInputs = [ pkg-config ];
+  # When cross-compiling, crossCC provides the `<host>-gcc`/`<host>-g++`
+  # (etc.) that the depends Makefile invokes for HOST packages; the native
+  # `gcc`/`g++` from the build stdenv stay the BUILD compiler for the
+  # native helper tools (native_capnp, mpgen, …).
+  nativeBuildInputs = [ pkg-config ] ++ crossInputs;
   buildInputs = [
     python3 libtool autoconf automake cmake which bison flex gperf
   ];
@@ -292,7 +309,7 @@ gcc14Stdenv.mkDerivation rec {
   # try_run checks (zmq_check_*, secp256k1's Valgrind detection, etc.) so
   # all the resulting depends archives and the secp256k1 region in the
   # final bitcoind match upstream's GUIX-built binary byte-for-byte.
-  makeFlags = [ "HOST=x86_64-linux-gnu" ];
+  makeFlags = [ "HOST=${hostTriple}" ] ++ lib.optionals (!buildQt) [ "NO_QT=1" ];
 
   # Override the nixpkgs gcc-wrapper's `-fno-omit-frame-pointer
   # -mno-omit-leaf-frame-pointer` (set in cc-cflags-before) so depends
@@ -340,7 +357,7 @@ gcc14Stdenv.mkDerivation rec {
   postFixup = ''
     # HOST=x86_64-linux-gnu (set in makeFlags) makes depends install
     # under x86_64-linux-gnu/ — move it to $out.
-    mv x86_64-linux-gnu/* $out/
+    mv ${hostTriple}/* $out/
 
     # The depends build hardcodes its absolute build-time staging path
     # (e.g. /build/.../depends/x86_64-linux-gnu) into CMake config
@@ -353,7 +370,16 @@ gcc14Stdenv.mkDerivation rec {
     # .a libraries keep the GUIX prefix (matching upstream's bitcoin-qt).
     find $out -type f \( -name '*.cmake' -o -name '*.pc' \) \
       -exec sed -i \
-        -e "s|/build/bitcoin-${version}/depends/x86_64-linux-gnu|$out|g" \
-        -e "s|/bitcoin/depends/x86_64-linux-gnu|$out|g" {} +
+        -e "s|/build/bitcoin-${version}/depends/${hostTriple}|$out|g" \
+        -e "s|/bitcoin/depends/${hostTriple}|$out|g" {} +
   '';
-}
+} // lib.optionalAttrs (crossInputs != [ ]) {
+  # When cross-compiling, unset the Nix-exported well-known tool vars so
+  # depends uses the <hostTriple>- cross toolchain for HOST packages (see
+  # crossInputs). The native `gcc` (default_build_CC) still builds the
+  # native helper tools. Added conditionally so the native x86_64
+  # derivation is byte-identical (no stray empty preBuild).
+  preBuild = ''
+    unset CC CXX AR RANLIB NM STRIP OBJCOPY OBJDUMP
+  '';
+})

--- a/flake.nix
+++ b/flake.nix
@@ -128,7 +128,7 @@
       };
     in {
       packages.${system} = {
-        inherit (drvs) depends bitcoind tarball dependsAarch64 bitcoindAarch64;
+        inherit (drvs) depends bitcoind tarball dependsAarch64 bitcoindAarch64 crossGlibc231;
         default = drvs.bitcoind;
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -128,7 +128,7 @@
       };
     in {
       packages.${system} = {
-        inherit (drvs) depends bitcoind tarball dependsAarch64 bitcoindAarch64 crossGlibc231;
+        inherit (drvs) depends bitcoind tarball dependsAarch64 bitcoindAarch64 tarballAarch64 crossGlibc231;
         default = drvs.bitcoind;
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -128,7 +128,7 @@
       };
     in {
       packages.${system} = {
-        inherit (drvs) depends bitcoind tarball;
+        inherit (drvs) depends bitcoind tarball dependsAarch64 bitcoindAarch64;
         default = drvs.bitcoind;
       };
     };

--- a/tarball.nix
+++ b/tarball.nix
@@ -22,15 +22,19 @@
 , url
 , sha256
 , bitcoind
+# Target triple in the archive name + the `bitcoind` arg's arch. Defaults to
+# x86_64; pass arch = "aarch64-linux-gnu" + the aarch64 bitcoind + expected
+# hash to assemble the aarch64 release archive.
+, arch ? "x86_64-linux-gnu"
+, expectedSha256 ? "d3e4c58a35b1d0a97a457462c94f55501ad167c660c245cb1ffa565641c65074"
 }:
 
 let
   src = fetchurl { inherit url sha256; };
   # SOURCE_DATE_EPOCH = `git log --format=%at -1` of the v31.0 tag.
   sourceDateEpoch = "1776286524";
-  expectedSha256 = "d3e4c58a35b1d0a97a457462c94f55501ad167c660c245cb1ffa565641c65074";
 in
-runCommandLocal "bitcoin-${version}-x86_64-linux-gnu.tar.gz"
+runCommandLocal "bitcoin-${version}-${arch}.tar.gz"
 {
   nativeBuildInputs = [ gnutar gzip coreutils ];
 } ''
@@ -83,5 +87,5 @@ runCommandLocal "bitcoin-${version}-x86_64-linux-gnu.tar.gz"
     echo "  actual:   $actual"
     exit 1
   fi
-  echo "OK: bitcoin-${version}-x86_64-linux-gnu.tar.gz matches upstream ($actual)"
+  echo "OK: bitcoin-${version}-${arch}.tar.gz matches upstream ($actual)"
 ''


### PR DESCRIPTION
Similar to #7, but for aarch64 binaries. For now, we can only cross build on `x86_64`.

Matching hashes are tested in CI.