### PR TITLE
Update to NixOS 26.05

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,13 @@ Reproduce the official Bitcoin Core GUIX release binary for
 `x86_64-pc-linux-gnu` using Nix, producing a binary with an identical
 sha256. Project tracking: https://github.com/0xB10C/bitcoind-gunix/issues/1.
 
-## Status (2026-06-06): migrated to nixos-26.05 — x86_64 fully reproduces
+## Status (2026-06-06): migrated to nixos-26.05 — all 21 artifacts reproduce
 
 The flake is pinned to `nixos-26.05` (was `nixos-25.11`, now deprecated).
-All 10 x86_64 binaries + the `.tar.gz` still byte-match upstream
-(`dae69848…` / tarball `d3e4c58a…`); the `postFixup` gate passes.
+All 10 x86_64 binaries + the `.tar.gz` (`dae69848…` / `d3e4c58a…`) AND all 10
+aarch64 binaries + its `.tar.gz` (`4de1d568…`) still byte-match upstream; both
+`postFixup` gates pass. The fixes are summarized below; the aarch64 specifics
+are at the end of this status block.
 
 26.05's default toolchain is gcc 15.2.0 + binutils 2.46 (25.11 was gcc 14 +
 binutils 2.44). Only `gcc14` stays 14.3.0. Three regressions had to be
@@ -38,13 +40,22 @@ fixed, all in code that ends up statically linked into the binaries:
    cstdlib/cmath generation; shipped glibc is all C) via `preConfigure`
    export + `makeFlags` in flake.nix's glibc231.
 
-**aarch64 on 26.05 is WIP.** The cross glibc231 gets the same gcc14-CC fix
-(`crossGlibc231` in default.nix, using `pkgsCrossAarch64.buildPackages.gcc14`
-— the build→target cross gcc14, NOT the target-native one), and now builds.
-But the aarch64 depends build then fails: `native_qt` (a *native* x86
-package) invokes an aarch64-native `g++` — a separate nixos-26.05 cross
-cc-wrapper / depends compiler-resolution regression, unrelated to
-reproducibility, still to be solved.
+**aarch64 on 26.05 also fully reproduces** (all 10 + tarball `4de1d568…`).
+Two cross-specific fixes, both from the same 26.05 splicing change where
+`pkgsCrossAarch64.gcc14.cc` resolves to the aarch64-**native** gcc (an ARM
+binary) instead of the build→target cross gcc:
+
+- **`crossGlibc231`** (default.nix): same bootstrap-glibc issue as x86 — the
+  cross glibc was built by the bootstrap cross gcc15. Force
+  `CC=${pkgsCrossAarch64.buildPackages.gcc14}/bin/aarch64-linux-gnu-gcc`
+  (the build→target cross gcc14) via `preConfigure` + `makeFlags`.
+- **`crossGuixGcc`** (default.nix): was wrapping `pkgsCrossAarch64.gcc14.cc`,
+  which on 26.05 is the aarch64-native gcc. The cc-wrapper setup-hook then
+  put that native gcc's bin (with UNPREFIXED `gcc`/`g++`) on the depends
+  build PATH, shadowing the native compiler and breaking `native_qt`'s CMake
+  compiler check. Switched to `pkgsCrossAarch64.buildPackages.gcc14.cc` (the
+  x86-runnable cross gcc, prefix-only binaries). The gas-NOP issue does NOT
+  affect aarch64 (cross gcc bakes `--with-as` = cross binutils 2.41).
 
 ## Status (2026-06-04): ALL release binaries byte-match (incl. GUI)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,46 @@ Reproduce the official Bitcoin Core GUIX release binary for
 `x86_64-pc-linux-gnu` using Nix, producing a binary with an identical
 sha256. Project tracking: https://github.com/0xB10C/bitcoind-gunix/issues/1.
 
+## Status (2026-06-06): migrated to nixos-26.05 — x86_64 fully reproduces
+
+The flake is pinned to `nixos-26.05` (was `nixos-25.11`, now deprecated).
+All 10 x86_64 binaries + the `.tar.gz` still byte-match upstream
+(`dae69848…` / tarball `d3e4c58a…`); the `postFixup` gate passes.
+
+26.05's default toolchain is gcc 15.2.0 + binutils 2.46 (25.11 was gcc 14 +
+binutils 2.44). Only `gcc14` stays 14.3.0. Three regressions had to be
+fixed, all in code that ends up statically linked into the binaries:
+
+1. **GOT relax-relocations** — 26.05's gcc14 assembles libstdc++ with
+   relaxable `R_X86_64_GOTPCRELX`; the link then relaxes 2 `_S_timezones`
+   GOT accesses, rippling `.text`/`.eh_frame`. Fixed by re-appending
+   `-Wa,-mrelax-relocations=no` to `CXXFLAGS_FOR_TARGET` in
+   `gcc14RebuiltWithGlibc231`'s `preBuild` (default.nix).
+2. **gas NOP-fill order** — binutils 2.46 pads alignment gaps short-first;
+   2.41 (GUIX) pads long-first (diverged `btree_release_tree_recursively`
+   at 0x181633). `depsBuildTarget` alone didn't fix it — native gcc has no
+   `--with-as`, so xgcc resolves `as` from PATH at build time, and a 2.46
+   `as` leaks in via `depsBuildBuild` (the gcc-wrapper-15.2.0 build
+   compiler). Fixed by `preConfigure` shadowing `as` with binutils 2.41 at
+   the front of PATH for the whole gcc build (default.nix).
+3. **glibc `__libc_csu_init`** — the function that walks `__init_array`
+   (csu, ~0xba4060). gcc15 emits r12/rbp register allocation; **gcc14 emits
+   r15/r14 == upstream** (verified by compiling `csu/elf-init.c` with both).
+   glibc is a stdenv *bootstrap* component, so `glibc.override { stdenv }`
+   is silently ignored — it's always built by the bootstrap compiler (gcc14
+   on 25.11, gcc15 on 26.05, which is exactly why 25.11 matched). Fixed by
+   forcing `CC=${pkgs.gcc14}/bin/gcc` (CC only — forcing CXX breaks glibc's
+   cstdlib/cmath generation; shipped glibc is all C) via `preConfigure`
+   export + `makeFlags` in flake.nix's glibc231.
+
+**aarch64 on 26.05 is WIP.** The cross glibc231 gets the same gcc14-CC fix
+(`crossGlibc231` in default.nix, using `pkgsCrossAarch64.buildPackages.gcc14`
+— the build→target cross gcc14, NOT the target-native one), and now builds.
+But the aarch64 depends build then fails: `native_qt` (a *native* x86
+package) invokes an aarch64-native `g++` — a separate nixos-26.05 cross
+cc-wrapper / depends compiler-resolution regression, unrelated to
+reproducibility, still to be solved.
+
 ## Status (2026-06-04): ALL release binaries byte-match (incl. GUI)
 
 Every binary in the upstream `bitcoin-31.0-x86_64-linux-gnu` release now

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,37 +201,70 @@ Working issue #6. Local reference artifacts (all gitignored):
 
 ### Task #2 finding — why the `.gnu_debuglink` CRC patch stays
 
+**This is NOT a toolchain-version issue.** A common misconception: "now
+that we pin GUIX's exact gcc/glibc/binutils versions, can we drop the CRC
+patch?" No. The patch has nothing to do with versions — we've matched
+GUIX's gcc 14.3.0 / glibc 2.31 / binutils 2.41 since the nixos-25.11 days
+and the `.dbg` still diverged then. The blockers are **recorded paths and
+the target triple**, which version-matching does not change.
+
 The CRC in a stripped binary is CRC32 of its `.dbg`. To drop the patch,
-our `.dbg` would have to be byte-identical to upstream's. It is not, and
-the reasons are structural, not incidental:
+our `.dbg` would have to be byte-identical to upstream's. It is not. The
+*stripped runtime binary* is already byte-equal (`dae69848…`); the entire
+divergence is debug-only. Decompressed, the two `.dbg` are 292,886,544
+(upstream) vs 292,713,176 (ours) — ~172 KB / 0.06 % apart, spread
+proportionally across every debug section. That 0.06 % is entirely
+**recorded paths** (`.debug_line_str` + the cascade of
+`.debug_str`/`.debug_info` offset shifts).
 
-- **Compression**: upstream's debug sections are SHF_COMPRESSED (GUIX's
-  binutils compresses by default); ours aren't. Fixable with `-gz`.
-- **Content is ~identical otherwise**: decompressed, the two `.dbg` are
-  292,886,544 (upstream) vs 292,713,176 (ours) — ~172 KB / 0.06 % apart,
-  spread proportionally across every debug section.
-- **That 0.06 % is recorded paths** (`.debug_line_str` and the cascade of
-  `.debug_str`/`.debug_info` offset shifts), and they diverge for reasons
-  we can't cheaply match:
-  - toolchain headers: ours `/nix/store/…gcc-14.3.0/include/c++/14.3.0`,
-    upstream `/usr/include/c++` (GUIX maps `/gnu/store/*`→`/usr`, *and*
-    lays c++ headers out without the version subdir);
-  - **target triple**: upstream `x86_64-linux-gnu` vs our gcc's
-    `x86_64-unknown-linux-gnu` — pervasive in include/lib paths and baked
-    into the gcc build;
-  - **GUIX ephemeral build dirs baked into libgcc/glibc debug info**:
-    `/tmp/guix-build-gcc-cross-x86_64-linux-gnu-14.3.0.drv-0/…` and
-    `/tmp/guix-build-glibc-cross-…/source/csu`. These come from the
-    compiler's own debug info (statically-linked csu/libgcc) and can't be
-    reproduced without rebuilding our gcc/glibc as `x86_64-linux-gnu`
-    cross toolchains with `-fdebug-prefix-map` to those exact `.drv-0`
-    paths.
+#### The four structural divergences (and the fix each needs)
 
-None of this affects the *stripped* runtime binary (already byte-equal at
-`dae69848…`); it's all debug-only. Matching it would mean a target-triple
-change plus deep path surgery across the whole toolchain — high cost, high
-risk, for a 4-byte debugger hint. So the CRC patch stays, and A patches the
-other binaries' CRCs the same way.
+To make the `.dbg` byte-identical, ALL four must be matched:
+
+1. **Debug sections not compressed.** Upstream's are `SHF_COMPRESSED`
+   (GUIX's binutils compresses by default); ours aren't.
+   *Fix:* add `-gz` to the debug build. **Effort: trivial.**
+
+2. **Target triple.** Ours is `x86_64-unknown-linux-gnu` (nixpkgs
+   default), GUIX's is `x86_64-linux-gnu`. Pervasive in include/lib paths
+   in the debug info and baked into the gcc build itself.
+   *Fix:* build x86_64 as a **cross-to-self** to `x86_64-linux-gnu` —
+   exactly the "cross everywhere" change we want anyway, and exactly what
+   the aarch64 path already does (`aarch64-linux-gnu`). **Effort: medium —
+   a real toolchain restructure, but mirrors the existing aarch64 setup.**
+
+3. **Toolchain header paths.** Ours `/nix/store/…gcc-14.3.0/include/c++/
+   14.3.0`; upstream `/usr/include/c++` (GUIX maps `/gnu/store/*`→`/usr`
+   *and* lays the c++ headers out without the version subdir).
+   *Fix:* `-ffile-prefix-map` to rewrite our store paths to GUIX's `/usr`
+   layout, including the version-less c++ header dir. **Effort: medium,
+   fiddly — has to match GUIX's exact layout, not just any /usr mapping.**
+
+4. **GUIX ephemeral build dirs baked into libgcc/glibc debug info.**
+   `/tmp/guix-build-gcc-cross-x86_64-linux-gnu-14.3.0.drv-0/…` and
+   `/tmp/guix-build-glibc-cross-…/source/csu`. These come from the
+   *compiler's own* debug info in the statically-linked csu/libgcc
+   members — they're already baked into the precompiled toolchain, not
+   into our per-file compiles.
+   *Fix:* rebuild **our** gcc and glibc with `-fdebug-prefix-map` pointing
+   at GUIX's *exact* `.drv-0` ephemeral paths. **Effort: large and
+   fragile — deep toolchain surgery to reproduce throwaway build-dir names
+   purely for debugger metadata.** This is the real blocker.
+
+#### Verdict
+
+Dropping the patch is **days of high-risk work for a 4-byte debugger
+hint** that doesn't affect the runtime binary or the shipped release
+`.tar.gz` (which contains no `.dbg`; we don't even assemble the separate
+`-debug.tar.gz`). So the CRC patch stays for all 10 binaries.
+
+**When we do the cross-to-self change** (planned regardless — see the
+"cross everywhere" goal), fix #2 falls out for free and fix #4 becomes
+reachable in the same toolchain rebuild (we'll already be rebuilding gcc/
+glibc as `x86_64-linux-gnu`, so adding the `-fdebug-prefix-map` flags
+there is incremental). At that point revisit dropping the CRC patch:
+do #1 + #3 alongside, and byte-identical `.dbg` (hence no CRC patch, and
+a reproducible `-debug.tar.gz`) becomes plausible. Until then, keep it.
 
 ### Upstream binary set (sha256, from the GUIX tarball)
 

--- a/bitcoind-aarch64.nix
+++ b/bitcoind-aarch64.nix
@@ -81,6 +81,9 @@ gcc14Stdenv.mkDerivation {
   hardeningDisable = [
     "zerocallusedregs" "strictoverflow" "stackprotector"
     "stackclashprotection" "fortify" "fortify3"
+    # New nixos-26.05 cc-wrapper defaults GUIX doesn't apply (see bitcoind.nix):
+    # strictflexarrays1 is codegen-affecting; libcxxhardeningfast is libc++-only.
+    "strictflexarrays1" "libcxxhardeningfast"
   ];
 
   # Mirror GUIX build.sh's split-debug + .gnu_debuglink handling (same as

--- a/bitcoind.nix
+++ b/bitcoind.nix
@@ -137,9 +137,15 @@ gcc14Stdenv.mkDerivation rec {
   #   core_interface only; secp256k1 was picking it up via the nixpkgs
   #   global and diverging in secp256k1_ellswift_xdh (FORTIFY __chk
   #   variants cause register-pressure differences).
+  # - strictflexarrays1: -fstrict-flex-arrays=1. New nixos-26.05 cc-wrapper
+  #   default; codegen-affecting (GUIX's gcc defaults to =0). Leaving it on
+  #   shifted the bytes of every binary on the 26.05 bump.
+  # - libcxxhardeningfast: -D_LIBCPP_HARDENING_MODE=…FAST. New 26.05 default,
+  #   libc++-only (we use libstdc++) — a no-op for us, dropped for cleanliness.
   hardeningDisable = [
     "zerocallusedregs" "strictoverflow" "stackprotector"
     "stackclashprotection" "fortify" "fortify3"
+    "strictflexarrays1" "libcxxhardeningfast"
   ];
 
   postInstall = ''

--- a/default.nix
+++ b/default.nix
@@ -61,6 +61,50 @@ let
     patches = (old.patches or []) ++ [
       ./patches/gcc-ssa-generation.patch
     ];
+    # Assemble this gcc's target libs (libstdc++, libgcc) with OUR binutils
+    # 2.41 (GUIX's version), not nixos-26.05's default 2.46. bitcoind links
+    # these libs statically from $cc/lib (verified via `ld -t`), so their
+    # assembler (gas) determines the bytes. binutils 2.46 changed the
+    # alignment-NOP fill order (short-first; 2.41/2.44 emit long-first),
+    # diverging libgcc/libstdc++ inter-function padding (e.g.
+    # btree_release_tree_recursively at 0x181633) from upstream's GUIX-2.41
+    # build — confirmed by byte-diffing our binary vs the upstream dae69848…
+    # release at that offset.
+    #
+    # Setting depsBuildTarget alone is NOT enough: the gcc derivation also
+    # pulls a 2.46 `as` onto PATH via depsBuildBuild (= buildPackages.stdenv.cc
+    # = the gcc-wrapper-15.2.0 build compiler, which propagates
+    # binutils-wrapper-2.46), and that 2.46 `as` wins the PATH lookup when the
+    # newly-built xgcc assembles the target libs. Since this gcc is native
+    # (no --with-as), the assembler is resolved purely from PATH at build time.
+    # So we ALSO shadow `as` with the 2.41 one at the very front of PATH for
+    # the whole gcc build (preConfigure below). A global binutils overlay would
+    # be the "clean" version but breaks the 26.05 stdenv bootstrap.
+    depsBuildTarget = [ bintoolsWithGlibc231 pkgs.patchelf ];
+    preConfigure = (old.preConfigure or "") + ''
+      # Shadow `as` (and the target-triple-prefixed alias) with binutils 2.41's
+      # so xgcc assembles libgcc/libstdc++ with the GUIX NOP-fill order.
+      mkdir -p "$TMPDIR/forceas/bin"
+      ln -sf ${binutilsForGuix}/bin/as "$TMPDIR/forceas/bin/as"
+      ln -sf ${binutilsForGuix}/bin/as "$TMPDIR/forceas/bin/x86_64-unknown-linux-gnu-as"
+      ln -sf ${binutilsForGuix}/bin/as "$TMPDIR/forceas/bin/x86_64-pc-linux-gnu-as"
+      export PATH="$TMPDIR/forceas/bin:$PATH"
+    '';
+    # Force NON-relaxable GOT relocs (R_X86_64_GOTPCREL, not …GOTPCRELX) in the
+    # target libs: gas honors the LAST -mrelax-relocations, and 2.41's default
+    # is relaxable. Must be in preBuild — gcc/common/builder.nix overwrites
+    # EXTRA_FLAGS_FOR_TARGET for native builds, then seeds makeFlagsArray with
+    # CXXFLAGS_FOR_TARGET; re-appending later wins. Without this the final link
+    # relaxes libstdc++'s std::__timepunct_cache<>::_S_timezones GOT accesses
+    # to direct, dropping 2 .got entries and rippling .text/.eh_frame (all 10
+    # hashes off). Upstream keeps those GOT entries.
+    preBuild = (old.preBuild or "") + ''
+      makeFlagsArray+=(
+        "CFLAGS_FOR_TARGET=$EXTRA_FLAGS_FOR_TARGET $EXTRA_LDFLAGS_FOR_TARGET -Wa,-mrelax-relocations=no"
+        "CXXFLAGS_FOR_TARGET=$EXTRA_FLAGS_FOR_TARGET $EXTRA_LDFLAGS_FOR_TARGET -Wa,-mrelax-relocations=no"
+        "FLAGS_FOR_TARGET=$EXTRA_FLAGS_FOR_TARGET $EXTRA_LDFLAGS_FOR_TARGET -Wa,-mrelax-relocations=no"
+      )
+    '';
     # Match GUIX's `linux-base-gcc` configure flags exactly, from
     # contrib/guix/manifest.scm:
     #
@@ -137,7 +181,12 @@ let
   # makes all cross compiles use glibc 2.31 headers/CRTs (vs nixpkgs 2.40)
   # — the .text (inline functions) + dynsym/version gap driver.
   # NOTE: --enable-cet is x86-only and omitted.
-  crossGlibc231 = pkgsCrossAarch64.glibc.overrideAttrs (old: {
+  # Built with the gcc-14 cross stdenv (nixos-26.05's default is gcc 15.2.0;
+  # the glibc CRT/nonshared members linked into the binaries must be gcc-14 —
+  # same reasoning as flake.nix's native glibc231).
+  crossGlibc231 = (pkgsCrossAarch64.glibc.override {
+    stdenv = pkgsCrossAarch64.gcc14Stdenv;
+  }).overrideAttrs (old: {
     version = "2.31";
     src = pkgs.fetchgit {
       name = "glibc-2.31";
@@ -176,7 +225,27 @@ let
     # protection defaults the compiler to, so it reproduces that codegen.
     env = (old.env or { }) // {
       NIX_CFLAGS_COMPILE = "-momit-leaf-frame-pointer -mbranch-protection=standard";
+      # Skip glibc's C++ link test — same nixos-26.05 reasoning as the native
+      # glibc231 (flake.nix): the cross build stdenv's libstdc++ is gcc 15's,
+      # built against a modern glibc, and won't link against the 2.31 being
+      # built. C++ is test-only here too; the installed glibc is pure C.
+      libc_cv_cxx_link_ok = "no";
     };
+    # Force the cross C compiler to gcc 14.3.0 (GUIX's version), exactly as
+    # flake.nix does for the native glibc231. glibc is a stdenv bootstrap
+    # component, so `.override { stdenv = … }` is ignored — on nixos-26.05 the
+    # cross glibc would otherwise build with the bootstrap cross gcc 15.2.0,
+    # giving __libc_csu_init the gcc-15 register allocation (diverges from
+    # upstream's gcc-14 codegen). Force CC only (not CXX — see flake.nix:
+    # forcing CXX breaks glibc's cstdlib/cmath generation; the shipped glibc
+    # is all C). `aarch64-linux-gnu-gcc` is the cross gcc14's driver name
+    # (targetPrefix = "aarch64-linux-gnu-").
+    preConfigure = (old.preConfigure or "") + ''
+      export CC=${pkgsCrossAarch64.buildPackages.gcc14}/bin/aarch64-linux-gnu-gcc
+    '';
+    makeFlags = (old.makeFlags or [ ]) ++ [
+      "CC=${pkgsCrossAarch64.buildPackages.gcc14}/bin/aarch64-linux-gnu-gcc"
+    ];
     # Disable the same nixpkgs hardenings flake.nix's x86_64 glibc231 drops.
     # The decisive one is zerocallusedregs (-fzero-call-used-regs): it
     # appends register-zeroing before `ret` in glibc's nonshared members
@@ -185,6 +254,10 @@ let
     hardeningDisable = [
       "zerocallusedregs" "strictoverflow" "stackprotector"
       "stackclashprotection" "fortify" "fortify3"
+      # New nixos-26.05 cross cc-wrapper defaults GUIX doesn't apply (see
+      # bitcoind.nix). strictflexarrays1 is codegen-affecting;
+      # libcxxhardeningfast is libc++-only (no-op for us).
+      "strictflexarrays1" "libcxxhardeningfast"
     ];
     postPatch = ''
       sed -i 's/ot \$/ot:\n\ttouch $@\n$/' manual/Makefile
@@ -256,10 +329,14 @@ let
   # approach's breakage (overlaying glibc hit the x86_64 *build* glibc too).
   # This closes the remaining gap: 2.31 headers (inline functions → .text /
   # .eh_frame) + 2.31 dynsym/symbol versions.
+  # NB: base the compiler on `gcc14`, not `stdenv.cc.cc` — nixos-26.05's
+  # default cross gcc is 15.2.0; we need GUIX's 14.3.0. The cc-wrapper itself
+  # (stdenv.cc) only contributes version-independent flags (-march=armv8-a,
+  # the frame-pointer defaults), so overriding just its `cc` is enough.
   crossGuixGcc = pkgsCrossAarch64.stdenv.cc.override {
     bintools = crossBintools241;
     libc = crossGlibc231;
-    cc = (pkgsCrossAarch64.stdenv.cc.cc.override {
+    cc = (pkgsCrossAarch64.gcc14.cc.override {
       libcCross = crossGlibc231;
     }).overrideAttrs (old: {
       configureFlags = (old.configureFlags or [ ]) ++ [

--- a/default.nix
+++ b/default.nix
@@ -329,14 +329,23 @@ let
   # approach's breakage (overlaying glibc hit the x86_64 *build* glibc too).
   # This closes the remaining gap: 2.31 headers (inline functions → .text /
   # .eh_frame) + 2.31 dynsym/symbol versions.
-  # NB: base the compiler on `gcc14`, not `stdenv.cc.cc` — nixos-26.05's
-  # default cross gcc is 15.2.0; we need GUIX's 14.3.0. The cc-wrapper itself
-  # (stdenv.cc) only contributes version-independent flags (-march=armv8-a,
-  # the frame-pointer defaults), so overriding just its `cc` is enough.
+  # NB: base the compiler on `buildPackages.gcc14`, not `gcc14` or
+  # `stdenv.cc.cc`. nixos-26.05's default cross gcc is 15.2.0; we need GUIX's
+  # 14.3.0. Critically, `pkgsCrossAarch64.gcc14.cc` resolves to the
+  # aarch64-NATIVE gcc (an ARM binary that can't run on the x86 build host) on
+  # 26.05 — wrapping it makes the cc-wrapper setup-hook put that native gcc's
+  # bin (with its UNPREFIXED `gcc`/`g++`) on the build PATH, where it shadows
+  # the depends build's native compiler and breaks native_qt's CMake compiler
+  # check ("ELF: not found"). `buildPackages.gcc14.cc` is the build→target
+  # cross gcc (runs on x86, prefix-only binaries), which is what we want. The
+  # cc-wrapper (stdenv.cc) only contributes version-independent flags
+  # (-march=armv8-a, the frame-pointer defaults), so overriding its `cc` is
+  # enough. (On nixos-25.11 the splice happened to give the cross gcc, so
+  # plain `gcc14.cc` worked there.)
   crossGuixGcc = pkgsCrossAarch64.stdenv.cc.override {
     bintools = crossBintools241;
     libc = crossGlibc231;
-    cc = (pkgsCrossAarch64.gcc14.cc.override {
+    cc = (pkgsCrossAarch64.buildPackages.gcc14.cc.override {
       libcCross = crossGlibc231;
     }).overrideAttrs (old: {
       configureFlags = (old.configureFlags or [ ]) ++ [

--- a/depends.nix
+++ b/depends.nix
@@ -367,6 +367,10 @@ gcc14Stdenv.mkDerivation (rec {
     "zerocallusedregs" "strictoverflow" "stackprotector"
     "stackclashprotection"
     "fortify" "fortify3" "format"
+    # New nixos-26.05 cc-wrapper defaults GUIX doesn't apply (see bitcoind.nix).
+    # strictflexarrays1 = -fstrict-flex-arrays=1 (codegen-affecting; GUIX gcc
+    # defaults to =0). libcxxhardeningfast is libc++-only (no-op for us).
+    "strictflexarrays1" "libcxxhardeningfast"
   ];
 
   doCheck = false;

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779102034,
-        "narHash": "sha256-vZJZjLo513IeI8hjzHFc6TDezUd4uCE2Eq4SNO3DNNg=",
+        "lastModified": 1780453794,
+        "narHash": "sha256-bXMRa9VTsHSPXL4Cw8R6JJLQeY3Y/IP4+YJCYVmQ7FY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "687f05a9184cad4eaf905c48b63649e3a86f5433",
+        "rev": "6b316287bae2ee04c9b93c8c858d930fd07d7338",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,29 +2,63 @@
   description = "bitcoind-gunix: reproduce GUIX bitcoind binary in Nix";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
   };
 
   outputs = { nixpkgs, ... }:
     let
       system = "x86_64-linux";
       pkgs = import nixpkgs { inherit system; };
-      # Build glibc 2.31 with nixpkgs-25.11's stdenv, which uses gcc 14.3.0
-      # — the *same* compiler version GUIX uses for its release toolchain.
-      # We take 25.11's modern glibc derivation and override it down to
-      # 2.31, fetching the exact source GUIX uses
-      # (contrib/guix/manifest.scm `define-public glibc-2.31`: the 2.31
-      # stable branch at commit 7b27c450). Building the CRTs and
+      # Build glibc 2.31 with gcc 14.3.0 — the *same* compiler version GUIX
+      # uses for its release toolchain. We take nixpkgs' modern glibc
+      # derivation and override it down to 2.31, fetching the exact source
+      # GUIX uses (contrib/guix/manifest.scm `define-public glibc-2.31`: the
+      # 2.31 stable branch at commit 7b27c450). Building the CRTs and
       # libc_nonshared.a objects with gcc 14 — rather than nixos-20.09's
       # gcc 8.3.0 — makes them carry the right .note.gnu.property USED
       # bytes, the gcc-14 `sub %fs:0x28,%rax` canary check, and the
       # gcc-14 __libc_csu_init register allocation natively, so no
       # post-install byte patching is needed.
       #
+      # `stdenv = pkgs.gcc14Stdenv` is required: nixos-26.05's default stdenv
+      # is gcc 15.2.0, and only `gcc14` still pins 14.3.0. The glibc CRTs /
+      # libc_nonshared.a members are compiled by this build stdenv and linked
+      # into the final binaries, so they must be gcc-14-built (gcc 15 would
+      # change their codegen and break the byte-match).
+      #
       # GUIX's glibc-2.31 configure flags (same manifest):
       #   --enable-stack-protector=all --enable-cet --enable-bind-now
       #   --disable-werror --disable-timezone-tools --disable-profile
-      glibc231 = pkgs.glibc.overrideAttrs (old: {
+      # Force glibc 2.31 to compile with gcc 14.3.0 (GUIX's version), not
+      # nixos-26.05's default gcc 15.2.0. This is the last x86_64-26.05
+      # divergence: glibc's statically-linked __libc_csu_init (csu, ~0xba4060
+      # in the binary — the function that walks __init_array calling each entry
+      # with argc/argv/envp) is the only function that differs, 129 bytes, pure
+      # register allocation. Confirmed by compiling csu/elf-init.c with both
+      # compilers: gcc14 emits r15=__init_array_start / r14=__init_array_end
+      # (== upstream dae69848…), gcc15 emits r12/rbp (== our previous 855820f0).
+      #
+      # glibc is a stdenv *bootstrap* component, so `.override { stdenv = … }`
+      # is silently ignored — the derivation is always built by the bootstrap
+      # stage compiler (gcc14 on nixos-25.11, gcc15 on nixos-26.05; that
+      # version bump is exactly why 25.11 matched and 26.05 didn't). The only
+      # lever that actually changes the compiler is overriding CC/CXX in the
+      # build itself: exported for `configure` and passed as makeFlags for the
+      # build. `pkgs.gcc14` is the stock 14.3.0 wrapper (its binutils 2.46 `as`
+      # is fine here — only the gcc codegen of __libc_csu_init was wrong; every
+      # other glibc member already matched). No GUIX gcc flags or SSA patch are
+      # needed for this — plain gcc14 reproduces upstream's csu exactly.
+      glibc231 = (pkgs.glibc.override { stdenv = pkgs.gcc14Stdenv; }).overrideAttrs (old: {
+        # Only force CC (the C compiler) — glibc's shipped code, including
+        # __libc_csu_init, is C. Leave CXX as the bootstrap default: glibc uses
+        # C++ only to generate the cstdlib/cmath compat headers, and forcing
+        # gcc14's g++ there breaks that generation (Makerules cstdlib/cmath).
+        preConfigure = (old.preConfigure or "") + ''
+          export CC=${pkgs.gcc14}/bin/gcc
+        '';
+        makeFlags = (old.makeFlags or [ ]) ++ [
+          "CC=${pkgs.gcc14}/bin/gcc"
+        ];
         version = "2.31";
         src = pkgs.fetchgit {
           # Name the checkout glibc-2.31 so the unpacked sourceRoot matches
@@ -67,6 +101,19 @@
         # cc-cflags-before. (25.11 glibc uses a structured `env`.)
         env = (old.env or { }) // {
           NIX_CFLAGS_COMPILE = "-fomit-frame-pointer -momit-leaf-frame-pointer";
+          # glibc uses C++ only for test programs (links-dso-program, the
+          # *-container helpers) — never for anything it installs. On
+          # nixos-26.05 the build stdenv's libstdc++ is gcc 15.2.0's, built
+          # against a modern glibc, so linking it against the 2.31 we're
+          # building fails (undefined fstat@GLIBC_2.33, pthread_*@GLIBC_2.34,
+          # arc4random@GLIBC_2.36, …). Pre-seed this autoconf cache var so
+          # configure skips the C++ link check, then clears CXX and drops
+          # every C++ test target. The installed glibc is pure C, so nothing
+          # we ship changes — this only removes test helpers. (On 25.11 the
+          # default stdenv was gcc 14 and glibc built with no stdenv override,
+          # so its C++ test linked the old bootstrap libstdc++ and this wasn't
+          # needed.)
+          libc_cv_cxx_link_ok = "no";
         };
         # GUIX's toolchain applies none of nixpkgs' compile hardenings.
         # The decisive one here is zerocallusedregs (-fzero-call-used-regs):
@@ -78,6 +125,10 @@
         hardeningDisable = [
           "zerocallusedregs" "strictoverflow" "stackprotector"
           "stackclashprotection" "fortify" "fortify3"
+          # New nixos-26.05 cc-wrapper defaults GUIX doesn't apply (see
+          # bitcoind.nix). strictflexarrays1 is codegen-affecting;
+          # libcxxhardeningfast is libc++-only (no-op for us).
+          "strictflexarrays1" "libcxxhardeningfast"
         ];
         # 25.11's postPatch seds nss/nss_files_fopen.c and
         # include/nss_files.h, which don't exist in 2.31. Keep only the


### PR DESCRIPTION
NixOS 26.05's default toolchain is gcc 15.2.0 + binutils 2.46 (25.11 was gcc 14 + binutils 2.44). Only `gcc14` stays 14.3.0. 