### PR TITLE
aarch64: byte-identical .dbg files - drop the CRC patch, add .#debugTarballAarch64

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,59 @@ Reproduce the official Bitcoin Core GUIX release binary for
 `x86_64-pc-linux-gnu` using Nix, producing a binary with an identical
 sha256. Project tracking: https://github.com/0xB10C/bitcoind-gunix/issues/1.
 
+## Status (2026-06-11, later): aarch64 .dbg ALSO byte-identical — NO byte patches left ANYWHERE
+
+The x86_64 `.dbg` recipe (next section) was mirrored onto the aarch64
+cross toolchain the same day, and after three build rounds all ten
+aarch64 `.dbg` files byte-match upstream's; the aarch64 `.gnu_debuglink`
+CRC patch — the last byte patch in the whole project — is removed, and
+`nix build .#debugTarballAarch64` assembles
+`bitcoin-31.0-aarch64-linux-gnu-debug.tar.gz` byte-identical to upstream
+(`91917647…`). bitcoind-aarch64.nix's gate now asserts all 20 aarch64
+artifacts. Every published artifact of BOTH releases (44 files: 2×10
+binaries, 2×10 .dbg, 4 tarballs) now reproduces exactly.
+
+The mirror was 1:1 (binutils compressed-debug-sections + bundled zlib,
+kernel headers 6.1.119, NoFp wrappers, glibc --disable-static-pie +
+default-PIE forced CC + pic-hardening-off + unsplit static libs + drv-0
+debug-prefix-map, libgcc -g multiplicity + GUIX maps, /usr header maps,
+DISTSRC=/distsrc-base/distsrc-31.0-aarch64-linux-gnu, RelWithDebInfo,
+frandom-seed strip, Qt posix ipc preseeds aarch64-gated in depends.nix)
+with three aarch64-only deltas:
+
+- **glibc's forced CC bakes `--enable-standard-branch-protection=yes`**
+  (verified in manifest.scm: GUIX's linux-base-gcc — the
+  base-gcc-for-libc — has it), replacing the previously EXPLICIT
+  `-mbranch-protection=standard` which was recorded in DW_AT_producer.
+  Same PAC/BTI codegen, clean producer. Frame pointers likewise: the
+  explicit `-momit-leaf-frame-pointer` died with the NoFp wrappers (the
+  aarch64 -O2 default = keep non-leaf, omit leaf = upstream).
+- **`--with-arch=armv8-a` FILTERED OUT of both gcc configures** (the
+  decisive aarch64-only find, round 3): nixpkgs configures the cross gcc
+  with it, and a configured --with-arch makes the gcc DRIVER self-inject
+  `-march=armv8-a` into every cc1 line via OPTION_DEFAULT_SPECS —
+  recorded in EVERY CU's DW_AT_producer (glibc, libgcc, bitcoind alike).
+  Upstream's GUIX gcc has no --with-arch. Stripping the wrapper's
+  cc-cflags-before `-march` injection (round 2) was necessary but not
+  sufficient — the producer-string position shift (-march moving after
+  -mbranch-protection) was the tell that a second injection source
+  existed. armv8-a is the aarch64 baseline default → codegen identical.
+- **kernel-headers map for libgcc's unwind-dw2.c** (`-ffile-prefix-map=
+  ${linuxHeaders61Aarch64}/include=/usr/include` in crossGuixGcc's
+  GUIXMAPS): its <asm/…>/<asm-generic/…> includes resolve through
+  glibc-dev's include SYMLINKS, which gcc canonicalizes to the
+  linux-headers store path — escaping the glibc-dev map that sufficed on
+  x86 (unwind-dw2-fde-dip.c there only needed <elf.h>, a real file).
+
+Methodology note: round 1 (the plain mirror) already got within ~5 KB /
+102 MB on bitcoind.dbg; the residue was localized by per-section size
+diff → .debug_line_str string diff (the unmapped kernel-header dirs in
+ONE line table at 0x136ce5b → DW_AT_stmt_list lookup → unwind-dw2.c) +
+unique-producer-set diff (the -march flag). After round 2, decompressed
+sections were size-identical except .debug_str at exactly +150 bytes =
+10 producer variants × " -march=armv8-a" — pointing straight at the
+configured --with-arch.
+
 ## Status (2026-06-11): .dbg BYTE-IDENTICAL — CRC patch GONE, -debug.tar.gz reproduces
 
 All ten `.dbg` debug files are now byte-identical to upstream's, so the
@@ -78,8 +131,8 @@ divergences weren't in that list at all):
   STT_FILE symtab entries were the final 96 bytes of
   bitcoin-qt.dbg/bitcoin-gui.dbg.
 
-The aarch64 `.dbg` are NOT yet byte-matched (the aarch64 toolchain keeps
-the old structure; its CRC patch stays) — same recipe applies if wanted.
+(The aarch64 `.dbg` were byte-matched with the same recipe later the
+same day — see the status section above.)
 
 ## Status (2026-06-10): "cross everywhere" — generalized over build hosts
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ nix build .#bitcoind --print-build-logs
 nix build .#tarball --print-build-logs
 sha256sum result        # -> d3e4c58a…
 
-# The debug-symbols archive (x86_64; all ten .dbg byte-identical too):
+# The debug-symbols archive (all ten .dbg byte-identical too):
 nix build .#debugTarball --print-build-logs
 sha256sum result        # -> 96e35061…
 
@@ -72,6 +72,10 @@ sha256sum result        # -> 96e35061…
 nix build .#bitcoindAarch64 --print-build-logs
 nix build .#tarballAarch64 --print-build-logs
 sha256sum result        # -> 4de1d568…
+
+# The aarch64 debug-symbols archive:
+nix build .#debugTarballAarch64 --print-build-logs
+sha256sum result        # -> 91917647…
 
 # Just the depends tree:
 nix build .#depends
@@ -91,13 +95,12 @@ bitcoin-tx,bitcoin-util,bitcoin-wallet}`, `libexec/{bitcoin-gui,
 bitcoin-node,test_bitcoin}`) and the `bitcoin-31.0-x86_64-linux-gnu.tar.gz`
 archive.
 
-For x86_64, the separate `bitcoin-31.0-x86_64-linux-gnu-debug.tar.gz` is
-**also reproduced** (`nix build .#debugTarball` → `96e35061…`): all ten
-`.dbg` debug files are byte-identical to upstream's, so no byte patching
-of any kind remains in the x86_64 pipeline (the historical
-`.gnu_debuglink` CRC patch is gone — the CRC now matches naturally).
-The aarch64 `.dbg` files are not yet byte-matched (their CRC patch
-remains); the runtime binaries and release archive reproduce as above.
+The separate debug-symbols archives are **also reproduced** for both
+targets (`nix build .#debugTarball` → `96e35061…`;
+`nix build .#debugTarballAarch64` → `91917647…`): all twenty `.dbg`
+debug files are byte-identical to upstream's, so no byte patching of any
+kind remains anywhere in the pipeline (the historical `.gnu_debuglink`
+CRC patches are gone — the CRCs now match naturally).
 
 ## Layout
 
@@ -115,9 +118,9 @@ remains); the runtime binaries and release archive reproduce as above.
   depends in cross-compile mode, matching GUIX either way).
 - `bitcoind.nix` / `bitcoind-aarch64.nix` — build all of Bitcoin Core via
   CMake with the prefixed cross compiler, then split-debug (cross binutils
-  2.41), `.comment` rewrite, `.gnu_debuglink` CRC patch, and assert all
-  ten binary hashes. The two differ in frame-pointer flags, ELF
-  interpreter, and the per-binary CRC/hash tables.
+  2.41) and `.comment` rewrite, and assert all twenty per-target hashes
+  (10 binaries + 10 `.dbg`). The two differ in the ELF interpreter and
+  the per-binary hash tables.
 - `tarball.nix` — assembles `bitcoin-31.0-<arch>-linux-gnu.tar.gz`
   byte-identical to upstream and asserts its hash (parameterized by `arch`).
 - `patches/` — patch files applied via the .nix derivations.

--- a/bitcoind-aarch64.nix
+++ b/bitcoind-aarch64.nix
@@ -3,7 +3,7 @@
 # to the upstream GUIX release. The aarch64 analog of bitcoind.nix; kept as a
 # separate file because the cross build differs structurally (cross compiler
 # via CC export, aarch64 ELF interpreter, cross binutils for split-debug,
-# aarch64 frame-pointer handling, per-binary CRCs/hashes).
+# aarch64 frame-pointer handling, per-binary hashes).
 { gcc14Stdenv
 , fetchurl
 , pkg-config
@@ -13,21 +13,26 @@
 , sha256
 , depends # the aarch64 depends tree (Qt included)
 , crossInputs # aarch64 cross cc/bintools (provides aarch64-linux-gnu-gcc/-objcopy/…)
+, guixGcc # the unwrapped cross gcc (crossGuixGcc.cc) — for header prefix-maps
+, linuxHeaders # kernel headers — gcc canonicalizes the sys-include symlinks to this store path
 }:
 
 let
-  # aarch64 frame pointers: upstream uses bare -O2, which on aarch64 KEEPS
-  # the non-leaf frame pointer but OMITS the leaf one. nixpkgs' cross
-  # cc-wrapper forces `-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer`
-  # (keep both). So we override only the leaf one back to omit — letting the
-  # wrapper's -fno-omit-frame-pointer keep the non-leaf FP, matching upstream.
-  # (On x86_64 the -O2 default omits both, hence bitcoind.nix uses
-  # -fomit-frame-pointer there; here we must NOT, or every non-leaf function
-  # loses its frame setup and the binary shrinks ~66 KB below upstream.)
-  cflags = "-O2 -g -momit-leaf-frame-pointer"
+  # Match GUIX's HOST_CFLAGS/HOST_CXXFLAGS: bare `-O2 -g` plus prefix maps,
+  # exactly like bitcoind.nix (see its comment for the full map reasoning).
+  # NO explicit frame-pointer flags: crossInputs is the NoFp wrapper
+  # variant, so the aarch64 -O2 default applies (keep the non-leaf frame
+  # pointer, omit the leaf one — what the previously explicit
+  # -momit-leaf-frame-pointer reproduced against the wrapper injection),
+  # and DW_AT_producer stays flag-free like upstream's.
+  cflags = "-O2 -g"
     + " -ffile-prefix-map=${depends}=/bitcoin/depends/aarch64-linux-gnu"
-    + " -ffile-prefix-map=/build/bitcoin-${version}=/bitcoin"
-    + " -ffile-prefix-map=/build/bitcoin-${version}/src=.";
+    + " -ffile-prefix-map=${guixGcc}/include/c++/14.3.0=/usr/include/c++"
+    + " -ffile-prefix-map=${guixGcc}/aarch64-linux-gnu/sys-include=/usr/include"
+    + " -ffile-prefix-map=${guixGcc}/lib/gcc=/usr/lib/gcc"
+    + " -ffile-prefix-map=${linuxHeaders}/include=/usr/include"
+    + " -fdebug-prefix-map=/build/bitcoin-${version}=/distsrc-base/distsrc-${version}-aarch64-linux-gnu"
+    + " -fdebug-prefix-map=/build/bitcoin-${version}/src=.";
 in
 gcc14Stdenv.mkDerivation {
   pname = "bitcoind-aarch64";
@@ -42,6 +47,10 @@ gcc14Stdenv.mkDerivation {
   # depends toolchain.cmake auto-enables BUILD_GUI + WITH_QRENCODE because the
   # Qt depends are present, so bitcoin-qt / libexec/bitcoin-gui build too.
   cmakeBuildDir = "build";
+  # GUIX doesn't pass a build type, so bitcoin's CMakeLists defaults to
+  # RelWithDebInfo; nixpkgs' cmake hook would force Release. Visible in
+  # DW_AT_producer (see bitcoind.nix); same effective codegen (-O2).
+  cmakeBuildType = "RelWithDebInfo";
   cmakeFlags = [
     "--toolchain=${depends}/toolchain.cmake"
     "-DBUILD_GUI_TESTS=OFF"
@@ -59,6 +68,11 @@ gcc14Stdenv.mkDerivation {
     # otherwise leave CC=gcc → native x86_64).
     export CC=aarch64-linux-gnu-gcc
     export CXX=aarch64-linux-gnu-g++
+
+    # Drop the -frandom-seed=<out-hash> appended by nixpkgs'
+    # reproducible-builds hook — recorded in DW_AT_producer (see
+    # bitcoind.nix).
+    export NIX_CFLAGS_COMPILE=$(echo "$NIX_CFLAGS_COMPILE" | sed 's/-frandom-seed=[^ ]*//')
 
     mkdir -p depends
     # mpgen's baked capnp_PREFIX is .../depends/aarch64-linux-gnu.
@@ -86,12 +100,18 @@ gcc14Stdenv.mkDerivation {
     "strictflexarrays1" "libcxxhardeningfast"
   ];
 
-  # Mirror GUIX build.sh's split-debug + .gnu_debuglink handling (same as
+  # Mirror GUIX build.sh's split-debug + .comment handling (same as
   # x86_64 bitcoind.nix). Use the CROSS binutils 2.41 (aarch64-linux-gnu-*
-  # from crossInputs) — not nixpkgs' native 2.44 — so strip/objcopy behave
-  # like upstream's. The .gnu_debuglink CRC is CRC32 of each .dbg, which
-  # isn't byte-reproducible (DWARF path/triple divergence, see CLAUDE.md
-  # Task #2), so we overwrite it with upstream's per-binary value.
+  # from crossInputs) — not nixpkgs' native one — so strip/objcopy behave
+  # like upstream's.
+  #
+  # NOTE: the historical .gnu_debuglink CRC32 byte-patch is GONE
+  # (2026-06-11, same day as x86_64's): the aarch64 .dbg files are now
+  # byte-identical to upstream's (same recipe as x86_64 — see CLAUDE.md —
+  # plus the aarch64-only --with-arch=armv8-a removal and the
+  # kernel-header map for libgcc's unwind-dw2.c), so objcopy
+  # --add-gnu-debuglink computes upstream's CRC naturally. The postFixup
+  # gate asserts the .dbg hashes too.
   postInstall = ''
     printf 'GCC: (GNU) 14.3.0\0' > comment.bin
     for rel in \
@@ -105,29 +125,12 @@ gcc14Stdenv.mkDerivation {
       aarch64-linux-gnu-strip --enable-deterministic-archives -p -s "$f"
       aarch64-linux-gnu-objcopy --enable-deterministic-archives -p --add-gnu-debuglink="$f.dbg" "$f"
       aarch64-linux-gnu-objcopy --update-section .comment=comment.bin "$f"
-      case "$(basename "$f")" in
-        bitcoin)        crc='\x95\x2c\x9d\xa9' ;;  # 0xa99d2c95
-        bitcoin-cli)    crc='\x6b\x5e\xd3\x3e' ;;  # 0x3ed35e6b
-        bitcoind)       crc='\x89\xe2\xe5\xe8' ;;  # 0xe8e5e289
-        bitcoin-tx)     crc='\x7f\x25\x4b\xa5' ;;  # 0xa54b257f
-        bitcoin-util)   crc='\x14\xdd\xda\xf5' ;;  # 0xf5dadd14
-        bitcoin-wallet) crc='\x01\xe9\x5e\x3f' ;;  # 0x3f5ee901
-        bitcoin-qt)     crc='\x64\xb1\xde\xe1' ;;  # 0xe1deb164
-        bitcoin-node)   crc='\x13\x70\xf1\x8b' ;;  # 0x8bf17013
-        bitcoin-gui)    crc='\xcf\x6b\xf1\xb3' ;;  # 0xb3f16bcf
-        test_bitcoin)   crc='\x2c\x63\x14\xe1' ;;  # 0xe114632c
-        *)              crc="" ;;
-      esac
-      if [ -n "$crc" ]; then
-        read -r doff dsize < <(aarch64-linux-gnu-readelf -SW "$f" | sed 's/\[[ 0-9]*\]//' \
-          | awk '/\.gnu_debuglink/{print strtonum("0x"$4), strtonum("0x"$5)}')
-        printf "$crc" | dd of="$f" bs=1 seek=$((doff + dsize - 4)) count=4 conv=notrunc status=none
-      fi
     done
   '';
 
-  # Reproducibility gate: assert every shipped binary byte-matches the
-  # upstream GUIX v31.0 aarch64-linux-gnu release.
+  # Reproducibility gate: assert every shipped binary AND every .dbg debug
+  # file byte-matches the upstream GUIX v31.0 aarch64-linux-gnu release
+  # (the .dbg are what ship in the separate -debug.tar.gz).
   postFixup = ''
     declare -A expected=(
       [bin/bitcoin]=c793384c78c11b2125d0b68cc62b05fab7a96d6438f005f9e375f7d4a41bfe4c
@@ -140,6 +143,16 @@ gcc14Stdenv.mkDerivation {
       [libexec/bitcoin-node]=f213271f7cec156be3d155c3c1012f4c226e2b9216a40215355a190105d1fad5
       [libexec/bitcoin-gui]=f85193a8b7f4323f612b92a5b7e19cda977f90bb9c26543d3f5277bf10c59291
       [libexec/test_bitcoin]=940fd792624130b36c1aef4fb4fc61723e622635478e7301bf37827caac9f1c5
+      [bin/bitcoin.dbg]=a8e722fcb8e30edb417d354aa7dab72b0d61fb4d31e3b735226d2c627b13e3f7
+      [bin/bitcoin-cli.dbg]=008409b760e5478e852ba0497fd9ea46b13b54a91dd095b39e64775c520243f9
+      [bin/bitcoind.dbg]=c9874604dc0c1f064a06c4bd9205b0ba0ec003e1e33c3aae319fc9640f535317
+      [bin/bitcoin-tx.dbg]=550ff80b5930b557f094a9f72ea2043ffd348cf02fa5374458c78bd80e4630f6
+      [bin/bitcoin-util.dbg]=c45b2b672038b9b005c8243adee79dc6239fc16b056a619a2dd5e7ca2c0ce08e
+      [bin/bitcoin-wallet.dbg]=ec150d2d38aab542e7ea1eb824adb16924c93924e78d82d23c1673c108523890
+      [bin/bitcoin-qt.dbg]=2c846fa6508cd70709fc1bd962331a6c7df9664a5a8195b71e0ebaf39f03188c
+      [libexec/bitcoin-node.dbg]=c17dcda063ccab62a1fb217899ad3f25c35496be38010ad0714fa894a76aa64c
+      [libexec/bitcoin-gui.dbg]=e516b319336cf01cbc897681df6cac81576f92210d5db644208c6b2b55485456
+      [libexec/test_bitcoin.dbg]=ae4076dcaecb75f0ba1164828c602b57823570eef6b5f4976841e5c5fb35afeb
     )
     fail=0
     for rel in "''${!expected[@]}"; do
@@ -153,8 +166,8 @@ gcc14Stdenv.mkDerivation {
         fail=1
       fi
     done
-    [ "$fail" = "0" ] || { echo "FAIL: one or more aarch64 binaries diverged from upstream GUIX v31.0"; exit 1; }
-    echo "OK: all 10 aarch64 binaries match upstream GUIX v31.0"
+    [ "$fail" = "0" ] || { echo "FAIL: one or more aarch64 binaries/.dbg diverged from upstream GUIX v31.0"; exit 1; }
+    echo "OK: all 10 aarch64 binaries and all 10 .dbg files match upstream GUIX v31.0"
   '';
 
   dontStrip = true;

--- a/default.nix
+++ b/default.nix
@@ -39,6 +39,52 @@ let
     crossSystem = { config = "aarch64-linux-gnu"; };
   };
 
+  # Kernel headers pinned to GUIX's 6.1.119 for the aarch64 target — same
+  # reasoning as linuxHeaders61 below (the headers VERSION leaks into the
+  # .dbg via <linux/rtnetlink.h> enum DIEs).
+  linuxHeaders61Aarch64 = pkgsCrossAarch64.linuxHeaders.overrideAttrs (o: {
+    version = "6.1.119";
+    src = pkgs.fetchurl {
+      url = "mirror://kernel/linux/kernel/v6.x/linux-6.1.119.tar.xz";
+      hash = "sha256-rs2vOdCoRKgc5MZ9na/4l56Ti7aQ309nn7u0lP5CMng=";
+    };
+  });
+
+  # Stock cross gcc14 wrapper used as crossGlibc231's forced CC — the
+  # aarch64 analog of gcc14X86NoFp below (see its comment for the full
+  # reasoning: glibc's statically-linked members carry debug info whose
+  # DW_AT_producer must record NO explicit flags, like upstream's).
+  # aarch64 delta: --enable-standard-branch-protection=yes is baked in
+  # (GUIX's linux-base-gcc — the base-gcc-for-libc that builds their
+  # glibc — has it; it makes the PAC/BTI codegen a compiler DEFAULT, so
+  # the previously explicit -mbranch-protection=standard, which would be
+  # recorded in DW_AT_producer, is dropped). --with-as/--with-ld point at
+  # cross binutils 2.41: gas GENERATES the .debug_line programs (and
+  # assembles glibc's .S CUs entirely); 2.46's encoding diverges.
+  # --with-arch=armv8-a (nixpkgs' platform default) is FILTERED OUT: a
+  # configured --with-arch makes the gcc DRIVER self-inject
+  # `-march=armv8-a` into every cc1 command line (OPTION_DEFAULT_SPECS),
+  # and cc1 records it in DW_AT_producer — upstream's GUIX gcc has no
+  # --with-arch and records no -march. armv8-a is the aarch64 compiler
+  # baseline either way, so codegen is identical (gates verify).
+  gcc14Aarch64NoFpCC = pkgsCrossAarch64.buildPackages.gcc14.cc.overrideAttrs (o: {
+    configureFlags = (builtins.filter (f: f != "--with-arch=armv8-a") (o.configureFlags or [ ])) ++ [
+      "--enable-default-pie=yes"
+      "--enable-standard-branch-protection=yes"
+      "--with-as=${crossBinutils241}/bin/aarch64-linux-gnu-as"
+      "--with-ld=${crossBinutils241}/bin/aarch64-linux-gnu-ld"
+    ];
+  });
+  gcc14Aarch64NoFp = (pkgsCrossAarch64.buildPackages.gcc14.override {
+    cc = gcc14Aarch64NoFpCC;
+  }).overrideAttrs (old: {
+    postFixup = (old.postFixup or "") + ''
+      substituteInPlace $out/nix-support/cc-cflags-before \
+        --replace-fail "-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer" "" \
+        --replace-fail "-march=armv8-a" ""
+    '';
+  });
+
   # aarch64 cross glibc 2.31 — GUIX git source, no patches, GUIX configure
   # flags, frame-pointer handling, postPatch/postInstall fixes for 2.31
   # (the same override set as crossGlibc231X86 below, with the aarch64
@@ -51,6 +97,7 @@ let
   # gcc-14-compiled to match upstream's codegen).
   crossGlibc231 = (pkgsCrossAarch64.glibc.override {
     stdenv = pkgsCrossAarch64.gcc14Stdenv;
+    linuxHeaders = linuxHeaders61Aarch64;
   }).overrideAttrs (old: {
     version = "2.31";
     src = pkgs.fetchgit {
@@ -73,42 +120,54 @@ let
         "--disable-werror"
         "--disable-timezone-tools"
         "--disable-profile"
+        # No -fpie in upstream's csu/crt DW_AT_producer — see
+        # crossGlibc231X86. The codegen stays PIE because the forced CC is
+        # default-PIE (gcc14Aarch64NoFpCC).
+        "--disable-static-pie"
       ];
-    # aarch64 keeps the non-leaf frame pointer at -O2 (omit only the leaf
-    # one), unlike x86_64's glibc231 which omits both — see the frame-pointer
-    # note in bitcoind-aarch64.nix. Without this, glibc's libc_nonshared.a
-    # members (atexit, the stat wrappers) lose their frame setup and come out
-    # ~12 bytes smaller than upstream's.
-    #
-    # -mbranch-protection=standard: glibc is built with the *stock* cross
-    # gcc, which lacks GUIX's --enable-standard-branch-protection. The only
-    # glibc code that ends up *in* the binary is the statically-linked
-    # members (libc_nonshared.a's atexit/stat wrappers, csu's
-    # __libc_csu_init/fini), and without branch protection they miss the
-    # paciasp/autiasp (PAC) + bti landing pads upstream's glibc has — ~8
-    # bytes/function. This flag is exactly what --enable-standard-branch-
-    # protection defaults the compiler to, so it reproduces that codegen.
+    # NO explicit codegen flags (upstream's glibc DW_AT_producer records
+    # bare `-g -O2`): the aarch64 -O2 default keeps the non-leaf frame
+    # pointer and omits the leaf one — exactly what the previously explicit
+    # -momit-leaf-frame-pointer reproduced against the wrapper's
+    # -fno-omit-frame-pointer injection; the forced CC below is the NoFp
+    # wrapper so nothing injects FP flags. Branch protection (PAC/BTI in
+    # the csu/nonshared members) comes from the forced CC's baked
+    # --enable-standard-branch-protection (replacing the previously
+    # explicit -mbranch-protection=standard). Same codegen, clean producer.
+    # The prefix maps mirror crossGlibc231X86's (GUIX's ephemeral
+    # glibc-cross-aarch64 build dir for DW_AT_comp_dir; /usr spellings for
+    # the forced CC's internal headers + the kernel headers).
     env = (old.env or { }) // {
-      NIX_CFLAGS_COMPILE = "-momit-leaf-frame-pointer -mbranch-protection=standard";
+      NIX_CFLAGS_COMPILE = "-fdebug-prefix-map=/build/glibc-2.31=/tmp/guix-build-glibc-cross-aarch64-linux-gnu-2.31.drv-0/source"
+        + " -ffile-prefix-map=${gcc14Aarch64NoFpCC}/lib/gcc=/usr/lib/gcc"
+        + " -ffile-prefix-map=${linuxHeaders61Aarch64}/include=/usr/include";
       # Skip glibc's C++ link test — the cross build stdenv's libstdc++ is
       # gcc 15's, built against a modern glibc, and won't link against the
       # 2.31 being built. C++ is test-only; the installed glibc is pure C.
       libc_cv_cxx_link_ok = "no";
     };
+    # Keep the debug info — glibc's statically-linked members' DWARF flows
+    # into the .dbg files; see crossGlibc231X86's note (nixpkgs'
+    # separateDebugInfo hook would add a recorded -ggdb and strip the
+    # members).
+    separateDebugInfo = false;
+    dontStrip = true;
     # Force the cross C compiler to gcc 14.3.0 (GUIX's version). glibc is a
     # stdenv bootstrap component, so `.override { stdenv = … }` is ignored
     # — on nixos-26.05 the cross glibc would otherwise build with the
     # bootstrap cross gcc 15.2.0, giving __libc_csu_init the gcc-15
     # register allocation (diverges from upstream's gcc-14 codegen). Force
     # CC only (not CXX — forcing CXX breaks glibc's cstdlib/cmath
-    # generation; the shipped glibc is all C).
-    # `aarch64-linux-gnu-gcc` is the cross gcc14's driver name
-    # (targetPrefix = "aarch64-linux-gnu-").
+    # generation; the shipped glibc is all C). Through the NoFp wrapper
+    # variant (gcc14Aarch64NoFp above). Also drop the
+    # -frandom-seed=<out-hash> appended by nixpkgs' reproducible-builds
+    # hook — it would be recorded in DW_AT_producer.
     preConfigure = (old.preConfigure or "") + ''
-      export CC=${pkgsCrossAarch64.buildPackages.gcc14}/bin/aarch64-linux-gnu-gcc
+      export CC=${gcc14Aarch64NoFp}/bin/aarch64-linux-gnu-gcc
+      export NIX_CFLAGS_COMPILE=$(echo "$NIX_CFLAGS_COMPILE" | sed 's/-frandom-seed=[^ ]*//')
     '';
     makeFlags = (old.makeFlags or [ ]) ++ [
-      "CC=${pkgsCrossAarch64.buildPackages.gcc14}/bin/aarch64-linux-gnu-gcc"
+      "CC=${gcc14Aarch64NoFp}/bin/aarch64-linux-gnu-gcc"
     ];
     # Disable the same nixpkgs hardenings crossGlibc231X86 drops.
     # The decisive one is zerocallusedregs (-fzero-call-used-regs): it
@@ -122,6 +181,10 @@ let
       # bitcoind.nix). strictflexarrays1 is codegen-affecting;
       # libcxxhardeningfast is libc++-only (no-op for us).
       "strictflexarrays1" "libcxxhardeningfast"
+      # "pic": see crossGlibc231X86 — the wrapper's default -fPIC injection
+      # breaks glibc's pie-default detection and would be recorded in
+      # DW_AT_producer where glibc passes no own pic/pie flag.
+      "pic"
     ];
     postPatch = ''
       sed -i 's/ot \$/ot:\n\ttouch $@\n$/' manual/Makefile
@@ -143,11 +206,11 @@ let
       ln -sf $out/lib/libdl.so.2 $out/lib/libdl.so
       test -f $out/lib/libutil.so.1 && ln -sf $out/lib/libutil.so.1 $out/lib/libutil.so
       touch $out/lib/libpthread.a
+      # Keep the static libs in $out/lib next to the shared ones, like
+      # GUIX's glibc — see crossGlibc231X86's note (`-static` links, e.g.
+      # Qt's configure-time feature probes, must find -lc/-lm). The
+      # $static output remains declared but empty.
       mkdir -p $static/lib
-      mv $out/lib/*.a $static/lib
-      mv $static/lib/lib*_nonshared.a $out/lib
-      test -f $out/lib/libutil.so.1 || mv $static/lib/libutil.a $out/lib
-      sed "/^GROUP/s|$out/lib/lib|$static/lib/lib|g" -i "$static"/lib/*.a
       cp $bin/bin/getconf $bin/bin/getconf_
       mv $bin/bin/getconf_ $bin/bin/getconf
     '';
@@ -160,7 +223,7 @@ let
   # `stdenv.cc.bintools.bintools`, NOT `binutils-unwrapped` (which is the
   # aarch64-native binutils and can't run on the build machine). Same
   # override as crossBinutils241X86.
-  crossBinutils241 = pkgsCrossAarch64.stdenv.cc.bintools.bintools.overrideAttrs (_: {
+  crossBinutils241 = pkgsCrossAarch64.stdenv.cc.bintools.bintools.overrideAttrs (old: {
     version = "2.41";
     src = pkgs.fetchurl {
       url = "mirror://gnu/binutils/binutils-2.41.tar.bz2";
@@ -170,6 +233,14 @@ let
     # default cross outputs (incl. `dev`) — the cross binutils' postInstall
     # references $dev.
     patches = [ ];
+    # Match GUIX's binutils compression config — same reasoning as
+    # crossBinutils241X86 below: --enable-compressed-debug-sections=all
+    # (upstream's .dbg sections are SHF_COMPRESSED with no explicit
+    # split-debug flag) and bundled zlib, not --with-system-zlib
+    # (identical 2.41 zlib ⇒ identical deflate bytes).
+    configureFlags =
+      (builtins.filter (f: f != "--with-system-zlib") (old.configureFlags or [ ]))
+      ++ [ "--enable-compressed-debug-sections=all" ];
   });
   crossBintools241 = pkgsCrossAarch64.stdenv.cc.bintools.override {
     bintools = crossBinutils241;
@@ -211,7 +282,10 @@ let
     cc = (pkgsCrossAarch64.buildPackages.gcc14.cc.override {
       libcCross = crossGlibc231;
     }).overrideAttrs (old: {
-      configureFlags = (old.configureFlags or [ ]) ++ [
+      # --with-arch filtered out — see gcc14Aarch64NoFpCC: the configured
+      # default makes the driver inject a recorded -march=armv8-a into
+      # every compile (bitcoind's CUs included); GUIX's gcc has none.
+      configureFlags = (builtins.filter (f: f != "--with-arch=armv8-a") (old.configureFlags or [ ])) ++ [
         "--enable-standard-branch-protection=yes"
         "--enable-default-pie=yes"
         "--enable-default-ssp=yes"
@@ -223,8 +297,51 @@ let
         "--disable-libquadmath"
         "--disable-libsanitizer"
         "--disable-nls"
+        # Re-point the baked --with-as/--with-ld at cross binutils 2.41
+        # (nixpkgs bakes the 2.46 wrapper; a second --with-as appended
+        # later wins). On aarch64 this is debug-only — gas generates the
+        # .debug_line programs and 2.46's encoding diverges; the code
+        # bytes never depended on gas here (fixed-width instructions, no
+        # NOP-fill choice — see crossGuixGccX86 for the x86 story).
+        "--with-as=${crossBinutils241}/bin/aarch64-linux-gnu-as"
+        "--with-ld=${crossBinutils241}/bin/aarch64-linux-gnu-ld"
       ];
       patches = (old.patches or [ ]) ++ [ ./patches/gcc-ssa-generation.patch ];
+      # Debug info for libgcc with upstream's exact DW_AT_producer
+      # `-g -g -g -O2 -O2 -O2` + GUIX's ephemeral gcc build dir for
+      # DW_AT_comp_dir — the aarch64 analog of crossGuixGccX86's preBuild
+      # (see its comment for the compile-line model that puts -g in
+      # CFLAGS_FOR_TARGET only and strips -O2 from FLAGS_FOR_TARGET).
+      # No -Wa,-mrelax-relocations here: GOTPCRELX is x86-only.
+      # -march=armv8-a is stripped from EXTRA_FLAGS_FOR_TARGET: nixpkgs
+      # puts the platform arch there, so it lands in every libgcc CU's
+      # DW_AT_producer — upstream's gcc build passes no -march (armv8-a IS
+      # the aarch64 baseline default; codegen-identical, the 10-hash gate
+      # verifies). The kernel-headers map covers libgcc's unwind-dw2.c:
+      # its <asm/…>/<asm-generic/…> includes resolve through the glibc-dev
+      # include SYMLINKS, which gcc canonicalizes to the linux-headers
+      # store path — so the glibc-dev map alone misses them (x86's
+      # unwind-dw2-fde-dip only needed <elf.h>, a real glibc-dev file).
+      preBuild = (old.preBuild or "") + ''
+        EXTRA_FLAGS_FOR_TARGET="''${EXTRA_FLAGS_FOR_TARGET/-march=armv8-a /}"
+        EXTRA_SANS_O2="''${EXTRA_FLAGS_FOR_TARGET/-O2 /}"
+        GUIXMAPS="-fdebug-prefix-map=/build/build=/tmp/guix-build-gcc-cross-aarch64-linux-gnu-14.3.0.drv-0/build -ffile-prefix-map=${pkgs.lib.getDev crossGlibc231}/include=/usr/include -ffile-prefix-map=${linuxHeaders61Aarch64}/include=/usr/include"
+        makeFlagsArray+=(
+          "CFLAGS_FOR_TARGET=$EXTRA_FLAGS_FOR_TARGET $EXTRA_LDFLAGS_FOR_TARGET $GUIXMAPS -g"
+          "CXXFLAGS_FOR_TARGET=$EXTRA_FLAGS_FOR_TARGET $EXTRA_LDFLAGS_FOR_TARGET $GUIXMAPS"
+          "FLAGS_FOR_TARGET=$EXTRA_SANS_O2 $EXTRA_LDFLAGS_FOR_TARGET $GUIXMAPS"
+        )
+      '';
+      # Keep libgcc's objects unstripped (their CUs ship in upstream's
+      # .dbg) but strip libstdc++/libsupc++ — upstream has no CUs from
+      # them (libsupc++'s C members would otherwise leak cp-demangle.c).
+      dontStrip = true;
+      postFixup = (old.postFixup or "") + ''
+        find $out -name 'libstdc++*.a' -o -name 'libsupc++*.a' | while read -r f; do
+          ${crossBinutils241}/bin/aarch64-linux-gnu-objcopy \
+            --enable-deterministic-archives --strip-debug "$f"
+        done
+      '';
     });
   };
 
@@ -234,6 +351,28 @@ let
   aarch64CrossInputs = [
     crossGuixGcc
     crossGuixGcc.bintools
+  ];
+
+  # Wrapper variant for the bitcoind compile that does NOT inject
+  # `-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer` — the aarch64
+  # analog of crossGuixGccX86NoFp (see its comment). With the injection
+  # gone, the aarch64 -O2 default applies: keep the non-leaf frame
+  # pointer, omit the leaf one — exactly what the previously explicit
+  # -momit-leaf-frame-pointer achieved, but with upstream's clean
+  # DW_AT_producer (bare `-O2 -g`). depends keeps the regular wrapper.
+  # (also strips the wrapper's -march=armv8-a injection — recorded in
+  # every CU's DW_AT_producer; upstream compiles with no -march, and
+  # armv8-a is the compiler default anyway).
+  crossGuixGccNoFp = crossGuixGcc.overrideAttrs (old: {
+    postFixup = (old.postFixup or "") + ''
+      substituteInPlace $out/nix-support/cc-cflags-before \
+        --replace-fail "-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer" "" \
+        --replace-fail "-march=armv8-a" ""
+    '';
+  });
+  aarch64CrossInputsNoFp = [
+    crossGuixGccNoFp
+    crossGuixGccNoFp.bintools
   ];
 
   # Cross-build the full depends tree (incl. the Qt6 GUI tree) with a *native*
@@ -255,13 +394,25 @@ let
     inherit version url sha256;
     inherit (pkgs) gcc14Stdenv;
     depends = dependsAarch64;
-    crossInputs = aarch64CrossInputs;
+    crossInputs = aarch64CrossInputsNoFp;
+    guixGcc = crossGuixGcc.cc;
+    linuxHeaders = linuxHeaders61Aarch64;
   };
   tarballAarch64 = pkgs.callPackage ./tarball.nix {
     inherit version url sha256;
     bitcoind = bitcoindAarch64;
     arch = "aarch64-linux-gnu";
     expectedSha256 = "4de1d568dedd48604f75132421bc0abeca432639589b49a3909c81db3a813112";
+  };
+  # The separate aarch64 -debug.tar.gz with the ten .dbg files —
+  # reproducible since 2026-06-11 (byte-identical .dbg, same recipe as
+  # x86_64's; see bitcoind-aarch64.nix).
+  debugTarballAarch64 = pkgs.callPackage ./tarball.nix {
+    inherit version url sha256;
+    bitcoind = bitcoindAarch64;
+    arch = "aarch64-linux-gnu";
+    debug = true;
+    expectedSha256 = "91917647aaf50965fc834e048256fce17e8f5590658c7e8de2879fb66cdc9a73";
   };
 
   # --- x86_64 cross-to-self toolchain ---
@@ -650,5 +801,5 @@ let
   };
 in {
   inherit depends bitcoind tarball debugTarball dependsAarch64 bitcoindAarch64 tarballAarch64
-    crossGlibc231 crossGlibc231X86 crossGuixGccX86;
+    debugTarballAarch64 crossGlibc231 crossGlibc231X86 crossGuixGccX86;
 }

--- a/depends.nix
+++ b/depends.nix
@@ -441,4 +441,17 @@ gcc14Stdenv.mkDerivation (rec {
       packages/qt.mk
     grep -q 'TEST_posix_shm' packages/qt.mk || { echo "qt.mk posix preseed sed failed"; exit 1; }
   '';
+} // lib.optionalAttrs (crossInputs != [ ] && lib.hasPrefix "aarch64" hostTriple) {
+  # aarch64 cross build: same Qt posix ipc preseed as the x86_64 block
+  # above (the sandbox-vs-GUIX-container configure-check divergence is
+  # host-independent; the two feature-gated-to-EMPTY objects contribute
+  # STT_FILE symtab entries to bitcoin-qt.dbg/bitcoin-gui.dbg). The
+  # hosts/linux.mk special-case does NOT apply here (it's x86-build-
+  # machine + x86-host only), so no linux.mk sed. A separate optionalAttrs
+  # block so the x86_64 depends derivation stays byte-identical.
+  postPatch = ''
+    sed -i 's|-DCMAKE_PREFIX_PATH=$(host_prefix)$|-DCMAKE_PREFIX_PATH=$(host_prefix) -DHAVE_GETTIME=ON -DHAVE_SHM_OPEN_SHM_UNLINK=ON -DTEST_posix_shm=ON -DTEST_posix_sem=ON|' \
+      packages/qt.mk
+    grep -q 'TEST_posix_shm' packages/qt.mk || { echo "qt.mk posix preseed sed failed"; exit 1; }
+  '';
 })

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
           drvs = import ./default.nix { inherit pkgs; };
         in {
           inherit (drvs) depends bitcoind tarball debugTarball dependsAarch64 bitcoindAarch64 tarballAarch64
-            crossGlibc231 crossGlibc231X86 crossGuixGccX86;
+            debugTarballAarch64 crossGlibc231 crossGlibc231X86 crossGuixGccX86;
           default = drvs.bitcoind;
         });
     };


### PR DESCRIPTION
This makes the aarch64 debug builds reproducible, allows us to drop the CRC patching for aarch64, and allows for building a matching `bitcoin-31.0-aarch64-linux-gnu-debug.tar.gz` tarball.

```
$ nix build .#debugTarballAarch64
$ sha256sum result
91917647aaf50965fc834e048256fce17e8f5590658c7e8de2879fb66cdc9a73
```