### PR TITLE
x86_64 and aarch64 macOS reproducible

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -252,6 +252,94 @@ jobs:
           echo "debug actual:   $actual"
           [ "$actual" = "$expected" ]
 
+  # The two macOS releases, cross-built on the same x86_64 runner with the
+  # bare clang/lld 19.1.4 toolchain + the Xcode SDK (fetched from the public
+  # bitcoincore.org mirror). Each job builds the full chain for one host —
+  # all five published artifacts (-unsigned.tar.gz/.zip, -codesigning.tar.gz,
+  # signed .tar.gz/.zip) — every one self-gating against the upstream GUIX
+  # v31.0 hashes, then re-asserts them externally for log visibility. The
+  # bitcoind step builds inside an unshare/userns chroot (for byte-identical
+  # LC_UUIDs); GitHub's ubuntu runners allow the nested user namespace the
+  # Nix sandbox needs for it. The SDK-embedding closures ARE pushed to
+  # Cachix (the SDK is already public on the depends-sources mirror).
+  build-darwin-x86:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-25.11
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - uses: cachix/cachix-action@v17
+        with:
+          name: 0xb10c-bitcoind-gunix
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix build .#tarballDarwinX86 -o result-unsigned-tar --print-build-logs
+      - run: nix build .#zipDarwinX86 -o result-unsigned-zip --print-build-logs
+      - run: nix build .#codesigningDarwinX86 -o result-codesigning --print-build-logs
+      - run: nix build .#signedDarwinX86 -o result-signed --print-build-logs
+      - name: Verify all 5 x86_64-apple-darwin artifacts match upstream GUIX v31.0
+        run: |
+          declare -A expected=(
+            [result-unsigned-tar]=d1d0174f07cf87d9af4318f7072350510fa0f1bf8d3d3b1ee7143ad5967b6bdf
+            [result-unsigned-zip]=b8d9b9915a1871ee12a3a9883fd47860028454fcd192864735f2e0d3a88b4735
+            [result-codesigning]=fccf54f31bd58a3f834add05fa5df36520313d936445c556be8f71ccf314b658
+            [result-signed/bitcoin-31.0-x86_64-apple-darwin.tar.gz]=56824dd705bc2a3b22d42e8aa02ed53498d491ff7c2c8aa96831333871887ead
+            [result-signed/bitcoin-31.0-x86_64-apple-darwin.zip]=8e230f36a2020072763adf742b20d95348cb20aaa0b0a918ca44ecdc83ac4efd
+          )
+          rc=0
+          for f in "${!expected[@]}"; do
+            actual=$(sha256sum "$f" | cut -d' ' -f1)
+            if [ "$actual" = "${expected[$f]}" ]; then
+              echo "OK:   $f"
+            else
+              echo "FAIL: $f  expected ${expected[$f]}  actual $actual"; rc=1
+            fi
+          done
+          exit $rc
+
+  build-darwin-arm64:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-25.11
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - uses: cachix/cachix-action@v17
+        with:
+          name: 0xb10c-bitcoind-gunix
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix build .#tarballDarwinArm64 -o result-unsigned-tar --print-build-logs
+      - run: nix build .#zipDarwinArm64 -o result-unsigned-zip --print-build-logs
+      - run: nix build .#codesigningDarwinArm64 -o result-codesigning --print-build-logs
+      - run: nix build .#signedDarwinArm64 -o result-signed --print-build-logs
+      - name: Verify all 5 arm64-apple-darwin artifacts match upstream GUIX v31.0
+        run: |
+          declare -A expected=(
+            [result-unsigned-tar]=48d34a140aeaacd63a4bd37c24ed1876df4b077c98a7e0dd9a4483d1032839f4
+            [result-unsigned-zip]=b639946d343114cca5d87b218aaece04d0d111374b725d90dffc7e2d1d3b99f5
+            [result-codesigning]=955563c720b4d5fc22a11d4b102940d605f1cb9eb0b564f50deb606412c631e5
+            [result-signed/bitcoin-31.0-arm64-apple-darwin.tar.gz]=a2d7a13b4da53d4a3e4c517f3a0269e2429813417bb320d3b268993cfdc545d0
+            [result-signed/bitcoin-31.0-arm64-apple-darwin.zip]=fc119a34915daac57e5fbdf181c9295d862d6843d52a9380e39dc0d0ac69cf20
+          )
+          rc=0
+          for f in "${!expected[@]}"; do
+            actual=$(sha256sum "$f" | cut -d' ' -f1)
+            if [ "$actual" = "${expected[$f]}" ]; then
+              echo "OK:   $f"
+            else
+              echo "FAIL: $f  expected ${expected[$f]}  actual $actual"; rc=1
+            fi
+          done
+          exit $rc
+
   # "Cross everywhere" verification on an AARCH64 build host. The flake
   # exposes the same pipeline per build system (attr names refer to the
   # TARGET), so on this arm runner `.#tarballAarch64` is an aarch64

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,69 @@ Reproduce the official Bitcoin Core GUIX release binary for
 `x86_64-pc-linux-gnu` using Nix, producing a binary with an identical
 sha256. Project tracking: https://github.com/0xB10C/bitcoind-gunix/issues/1.
 
+## Status (2026-06-13): darwin x86_64 -unsigned artifacts REPRODUCE — all 10 binaries + .tar.gz + .zip; qt/gui LC_UUID patched
+
+The full x86_64-apple-darwin `-unsigned` set byte-matches upstream:
+`nix build .#bitcoindDarwinX86` gates all 10 Mach-O binaries,
+`.#tarballDarwinX86` the `-unsigned.tar.gz` (`d1d0174f…`) and
+`.#zipDarwinX86` the `-unsigned.zip` (`b8d9b991…`). Round-2 closed the
+three round-1 root causes; two follow-on fixes + one accepted patch
+finished it:
+
+- **kj fibers — the LIBRARY_PATH must be a CURATED union.** Mirroring
+  GUIX's `LIBRARY_PATH=$NATIVE_GCC/lib` with the RAW gcc+glibc lib dirs
+  broke capnp's own tool links: `ld64.lld: …/glibc-2.42/lib/libpthread.so:
+  unhandled file type`. nixpkgs' glibc 2.42 ships unversioned COMPAT
+  SYMLINKS (libpthread/librt/libdl/libutil/libanl.so → .so.N, ELF stubs)
+  that vanilla glibc dropped when those libs merged into libc in 2.34;
+  capnp's `-lpthread` (CMake Threads) then hands ld64.lld the ELF and
+  dies, where GUIX's `-lpthread` falls through to the SDK tbd. Fix:
+  `darwinLibraryPathDir` in depends.nix — a runCommand union of gcc's lib
+  + glibc's lib MINUS exactly those five compat links (one dir, like
+  GUIX's). Re-verified both directions with direct clang/ld64.lld link
+  tests: `-lpthread` links, `-lc` still errors (so the fibers
+  makecontext check fails → KJ_USE_FIBERS=0, matching upstream).
+- **LC_UUID — chroot fix WORKS for 8/10; qt/gui patched.** Building
+  inside the unshare/userns chroot at GUIX's `/distsrc-base/distsrc-31.0-
+  x86_64-apple-darwin` (depends at `/bitcoin/depends/<host>`) makes 8 of
+  10 binaries byte-identical INCLUDING the UUID. bitcoin-qt and
+  bitcoin-gui remained off by EXACTLY the 8 lld UUID digest bytes (byte 3
+  + bytes 9-15 of the `"LLD\xa1UU1D"`+digest+swap(3,8) layout); the
+  stripped images are otherwise byte-identical. The UUID is an xxh3 of
+  the UNSTRIPPED link-time image, and the differing bytes live entirely
+  in the Qt symtab/stabs region that `cmake --install --strip` removes
+  AFTER lld hashes it. Ruled out every path leak (all N_SO/N_OSO stabs
+  are GUIX-correct /distsrc-base, zero nix-store refs), .llvm./outlined/
+  cold symbols, and codegen (__TEXT byte-identical). The residual is in
+  the Qt local-symbol/stab content or ordering of the unstripped image;
+  pinning it needs a GUIX darwin reference to diff against, which is
+  UNAVAILABLE here (no guix binary, no darwin output in the local
+  guix-build — only upstream's STRIPPED binary, which has no symtab).
+  Matching the UUID is also REQUIRED for the signed artifacts (the
+  detached-sig cdhash covers it). Decision (user-approved): copy
+  upstream's literal UUID into exactly bitcoin-qt + bitcoin-gui post-link
+  — the darwin analog of the historical .gnu_debuglink CRC patch.
+  `patch-uuid.py` (new repo file; walks Mach-O load commands to LC_UUID
+  0x1b, overwrites 16 bytes), `uuidPatches` knob in bitcoind-darwin.nix
+  (values from the upstream -unsigned binaries), applied to $out/bin/
+  bitcoin-qt + $out/libexec/bitcoin-gui AND the deploy app's
+  Contents/MacOS/Bitcoin-Qt.
+- **-unsigned.zip mode fix.** macdeployqtplus copies Qt's translations
+  (Contents/Resources/qt_*.qm) straight from the read-only Nix store →
+  mode 0444 → zip records the DOS read-only bit (external_attr
+  0x81240001); upstream's GUIX deploy has them 0644 (0x81a40000). Fix:
+  `chmod -R u+w build/dist/Bitcoin-Qt.app` before re-zipping (a no-op for
+  the already-0755/0644 entries). The app binary is byte-identical to
+  bin/bitcoin-qt, so it's UUID-patched too, then the zip is regenerated
+  deterministically with the same cmake/script/macos_zip.sh
+  (SOURCE_DATE_EPOCH touch + find|sort|zip -X@).
+
+Outstanding for darwin: arm64 mirror (building — depends rebuilt for the
+LIBRARY_PATH-union change), then the SIGNED artifacts (signapple +
+bitcoin-core/bitcoin-detached-sigs) and -codesigning.tar.gz; the UUID
+patch already makes the to-be-signed binaries upstream-identical so the
+detached sigs will apply cleanly. After darwin: win64.
+
 ## Status (2026-06-12, evening): macOS started — clang/lld 19.1.4 toolchain pinned, SDK staged, plan laid out
 
 The macOS targets (arm64-/x86_64-apple-darwin, the next issue-#6 items)
@@ -75,6 +138,84 @@ unsigned artifact assembly + gates; then signapple + detached-sigs for
 the signed artifacts. Risk #1 is Qt 6.8.3-darwin cross in the Nix
 sandbox (expect posix_shm-style feature-check divergences). NOTE: the
 SDK (and anything embedding it) must not be pushed to public Cachix.
+
+## Status (2026-06-12, night): darwin x86_64 ROUND 1 — within 8 bytes on 7/10 binaries; all three root causes identified, round 2 in flight
+
+The full darwin pipeline now BUILDS end-to-end in the sandbox (depends
+incl. Qt 6.8.3, all 10 Mach-O binaries, the deploy app zip), wired as
+`dependsDarwin{X86,Arm64}` / `bitcoindDarwin{X86,Arm64}` (new
+bitcoind-darwin.nix; manual cmake — the nixpkgs cmake hook would inject
+-DCMAKE_C_COMPILER over the toolchain's multi-token clang) +
+`tarballDarwin*` / `zipDarwin*` artifact drvs with upstream-hash gates.
+Round 1 vs upstream (per-binary refs extracted from the published
+-unsigned.tar.gz into tmpdiff/upstream-darwin/): 7 of 10 binaries
+byte-identical EXCEPT the 8 bytes of LC_UUID; bitcoin-qt additionally
+diverged in qt_prfxpath (+ its inlined strlen immediate — both already
+fixed by the existing qt.mk -prefix sed which the interactive replay
+lacked); bitcoin-node/bitcoin-gui/test_bitcoin additionally carried
++4.4 KB of kj FIBER code. Replay trick for darwin: `nix develop
+.#dependsDarwinX86` + `make -C depends HOST=… SDK_PATH=… SOURCES_PATH=…`
+in tmpdiff/darwin-replay iterates qt-configure-level problems in
+minutes; bitcoind replays build straight against the replay depends.
+
+Three root causes, each verified at the byte/check level:
+
+- **CMake's PATH-prefix find probing poisons darwin try_compiles.**
+  find_library derives search prefixes from every $PATH entry (strip
+  /bin, probe <prefix>/lib) → finds the BUILD glibc's ELF librt.so →
+  Qt's FindWrapRt link checks die in ld64.lld ("unhandled file type") →
+  qt configure aborts ("Target Core links to WrapRt::WrapRt…"); zeromq's
+  find_library(RT_LIBRARY rt) would leak -lrt into zmq.pc. Upstream's
+  build succeeding proves GUIX's find is NOTFOUND (glibc 2.39 ships no
+  unversioned librt.so; nixpkgs' 2.42 does). Fix: darwin-only
+  `CMAKE_SYSTEM_IGNORE_PATH=<stdenv-glibc>/lib` via funcs.mk + qt.mk
+  seds (depends.nix postPatch). NOT -DLIBRT=…-NOTFOUND (find_library
+  re-runs on -NOTFOUND values) and NOT
+  CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF (kills find_program's
+  make/compiler lookup — tried, both rejected by test).
+- **capnp/kj fibers: GUIX's LIBRARY_PATH export is load-bearing.**
+  build.sh:80 exports LIBRARY_PATH=$NATIVE_GCC/lib for the darwin
+  DEPENDS build (unset again after depends). GUIX's gcc-toolchain is a
+  UNION incl. glibc (commencement.scm), so that dir holds glibc's ASCII
+  libc.so linker script; clang forwards LIBRARY_PATH to the target link
+  → ld64.lld errors on the script → capnp's
+  check_library_exists(c makecontext) FAILS in GUIX's container →
+  KJ_USE_FIBERS=0. Our env had no LIBRARY_PATH → -lc resolved to the
+  SDK's libc.tbd → fibers ON → the 3 multiprocess-linking binaries
+  gained fiber code + getcontext/setcontext/makecontext/mprotect/
+  setjmp imports upstream lacks. Fix: depends.nix darwin env mirrors it.
+  Verified: the check flips fail/pass with the env var alone, exact
+  ld64.lld error reproduced. **But NOT the raw gcc+glibc lib dirs**
+  (round-2 lesson): nixpkgs' glibc 2.42 installs unversioned COMPAT
+  SYMLINKS for the 2.34-merged libs (libpthread.so→libpthread.so.0,
+  librt/libdl/libutil/libanl.so) that vanilla glibc — GUIX's — never
+  ships; with those on LIBRARY_PATH, capnp's tool links (-lpthread via
+  CMake Threads) hand ld64.lld the ELF stub and die ("unhandled file
+  type"), while GUIX's -lpthread falls through to the SDK tbd. Fix:
+  `darwinLibraryPathDir` in depends.nix — a runCommand union of gcc's
+  lib + glibc's lib MINUS exactly those five compat links (one dir,
+  like GUIX's $NATIVE_GCC/lib). Both directions re-verified by direct
+  clang/ld64.lld link tests: -lpthread links, -lc still errors.
+- **LC_UUID fossilizes the pre-strip build paths.** lld computes the
+  UUID as xxhash(unstripped output + output basename) BEFORE the
+  install-time `cmake --install --strip`; the unstripped image carries
+  the linker's debug-map stabs — N_SO (absolute source paths) + N_OSO
+  (absolute object/archive paths) for bitcoin's OWN TUs (depends
+  archives contribute none — verified; only the qt_prfxpath .rodata
+  string carries a depends path and the -prefix sed pins it) — which
+  strip removes. Byte-equal UUID therefore requires byte-equal
+  UNSTRIPPED images = GUIX's literal paths. The sandbox root is
+  read-only (mkdir /distsrc-base → EPERM), but USER NAMESPACES WORK
+  inside the Nix sandbox: bitcoind-darwin.nix builds inside an
+  `unshare --user --map-root-user --mount` chroot with a bind-mounted
+  new root — source tree at /distsrc-base/distsrc-31.0-<host>, depends
+  symlinked at /bitcoin/depends/<host>, --toolchain spelled through it
+  (toolchain.cmake is fully CMAKE_CURRENT_LIST_DIR-relative, so every
+  depends path then matches GUIX's BASEPREFIX spellings).
+
+Round 2 (all three fixes) is building. Ops note: an auto-GC collected
+the 19.1.4 toolchain mid-session (built with --no-link, no root) — keep
+out-links (e.g. result-llvm-tools) for the darwin toolchain pieces.
 
 ## Status (2026-06-12, later): armhf + ppc64 .dbg loclists residue SOLVED — all 7 .dbg byte-identical, CRC patches GONE again, debug tarballs wired
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,11 +63,44 @@ finished it:
   deterministically with the same cmake/script/macos_zip.sh
   (SOURCE_DATE_EPOCH touch + find|sort|zip -X@).
 
-Outstanding for darwin: arm64 mirror (building — depends rebuilt for the
-LIBRARY_PATH-union change), then the SIGNED artifacts (signapple +
-bitcoin-core/bitcoin-detached-sigs) and -codesigning.tar.gz; the UUID
-patch already makes the to-be-signed binaries upstream-identical so the
-detached sigs will apply cleanly. After darwin: win64.
+## Status (2026-06-13, later): ALL 10 darwin artifacts REPRODUCE — both arches, incl. -codesigning + SIGNED
+
+macOS is DONE. Both arm64 and x86_64 now reproduce all FIVE published
+artifacts each (10 total): -unsigned.tar.gz, -unsigned.zip,
+-codesigning.tar.gz, signed .tar.gz, signed .zip — every one byte-matches
+upstream's SHA256SUMS and self-gates:
+
+```
+x86_64                              arm64
+fccf54f3…  -codesigning.tar.gz      955563c7…
+56824dd7…  signed .tar.gz           a2d7a13b…
+8e230f36…  signed .zip              fc119a34…
+(+ the -unsigned.tar.gz/.zip from the prior status section)
+```
+
+- **signapple.nix** packages GUIX's exact signing toolchain: signapple
+  @85bfcec + elfesteem @2eb1e53 (GUIX overrides signapple's own pyproject
+  elfesteem pin, so we do too) + the achow101 **certvalidator FORK**
+  @a145bf25 (signapple's `apply` verifies the result, hitting
+  ValidationContext(additional_critical_extensions=…) which stock
+  certvalidator lacks — stock fails with TypeError); asn1crypto + oscrypto
+  1.3.0 from nixpkgs. Pure python, runs on Linux (no macOS APIs on the
+  apply path). `.#signapple`.
+- **detachedSigs** = bitcoin-core/bitcoin-detached-sigs @v31.0 (c88e80d8);
+  osx/<host>/{bitcoin-31.0/{bin,libexec}/*.<arch>sign, dist/Bitcoin-Qt.app/…}.
+- **darwin-codesigning.nix** assembles the -codesigning.tar.gz =
+  unsigned-app/{detached-sig-create.sh, dist/Bitcoin-Qt.app, bitcoin-31.0/}
+  (the bitcoin-31.0/ tree is byte-for-byte the -unsigned.tar.gz content, so
+  it's extracted from the already-verified tarballDarwin), same
+  deterministic find|sort|tar --mode|gzip -9n as the release archives.
+- **darwin-signed.nix** mirrors codesign.sh: extract the codesigning
+  tarball, `signapple apply` the app bundle + each binary in place, then
+  the signed .zip (find|sort|zip -X@ over dist/) and signed .tar.gz
+  (find|sort|tar over bitcoin-31.0/). Because the UUID-patched unsigned
+  binaries are already upstream-identical, applying upstream's detached
+  sigs reproduces the signed bytes exactly — confirmed for all four.
+
+Issue #6 remaining: win64 only.
 
 ## Status (2026-06-12, evening): macOS started — clang/lld 19.1.4 toolchain pinned, SDK staged, plan laid out
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,76 @@ Reproduce the official Bitcoin Core GUIX release binary for
 `x86_64-pc-linux-gnu` using Nix, producing a binary with an identical
 sha256. Project tracking: https://github.com/0xB10C/bitcoind-gunix/issues/1.
 
+## Status (2026-06-12, evening): macOS started — clang/lld 19.1.4 toolchain pinned, SDK staged, plan laid out
+
+The macOS targets (arm64-/x86_64-apple-darwin, the next issue-#6 items)
+are underway. 10 upstream artifacts to reproduce (5 per host):
+`-unsigned.tar.gz` (48d34a14… arm64 / d1d0174f… x86_64), `-unsigned.zip`
+(b639946d… / b8d9b991…), `-codesigning.tar.gz` (955563c7… / fccf54f3…),
+and the SIGNED `.tar.gz` (a2d7a13b… / 56824dd7…) + `.zip` (fc119a34… /
+8e230f36…) — the signed ones are reproducible too: codesign.sh applies
+detached signatures (bitcoin-core/bitcoin-detached-sigs) with signapple
+(pure python, pinned in manifest.scm), then re-tars/zips deterministically.
+
+Structural differences vs the Linux targets (all verified in
+manifest.scm/build.sh/darwin.mk):
+- GUIX's darwin toolchain is just **clang-toolchain-19 + lld-19 (as ld)
+  + zip + signapple** — no cross-gcc/glibc/binutils at all. depends/
+  hosts/darwin.mk passes every cross flag explicitly (--target,
+  -isysroot SDK, -nostdlibinc, -iwithsysroot, -mmacos-version-min=14.0,
+  -mlinker-version=711, -Wl,-platform_version,macos,14.0,14.0,
+  -Wl,-no_adhoc_codesign -fuse-ld=lld) against a bare `clang` from PATH.
+- build.sh **unsets HOST_CFLAGS for darwin** → no `-g` anywhere, no
+  DWARF, no .dbg/debug-tarball, no split-debug; install is
+  `cmake --install --strip` (llvm-strip). Mach-O has no .comment and no
+  DW_AT_producer ⇒ compile flags are never recorded — prefix-map flags
+  may be added freely if `__FILE__` paths leak.
+- depends darwin set: boost libevent qrencode qt sqlite zeromq capnp +
+  native_{capnp,libmultiprocess,qt} — NO X11 stack.
+- App zip: `cmake --build build -t deploy` → macdeployqtplus builds
+  dist/Bitcoin-Qt.app, cmake/script/macos_zip.sh zips it (SOURCE_DATE_
+  EPOCH touch + find|sort|zip -X@).
+
+Done so far (committed in this change):
+- **macOS SDK staged**: `Xcode-26.1.1-17B100-extracted-SDK-with-libcxx-
+  headers` lives on the public mirror at https://bitcoincore.org/
+  depends-sources/sdks/ (filename from darwin.mk, `.tar`, sha256
+  9600fa93… = the hash in contrib/macdeploy/README.md). Downloaded +
+  extracted into `bitcoin/depends/SDKs/` (gitignored; NEVER commit), and
+  the future depends wiring can plain-`fetchurl` it like other sources.
+- **LLVM/clang/lld pinned to GUIX's 19.1.4** (nixpkgs-26.05 ships
+  19.1.7): `pkgsLlvm1914` in default.nix — an OVERLAY-based nixpkgs
+  import (not a bare `llvmPackages_19.override`: LLVM_TABLEGEN comes
+  from buildPackages via the splice machinery, which a local override
+  doesn't reach — it would have run a 19.1.7 tblgen over 19.1.4 .td
+  files; the overlay makes the splice self-consistent, tblgen = 19.1.4).
+- **`clangDarwin` reunites the resource dir**: nixpkgs puts clang's
+  builtin headers (stdarg.h…) in the separate `lib` output and reglues
+  them via the cc-wrapper, which we deliberately DON'T use (GUIX uses
+  bare clang; no wrapper = no injected-flag battles). clang realpaths
+  its executable to find the resource dir, so symlinks don't work —
+  `clangDarwin` is a copy-join of bin/ + complete lib/clang/19.
+- **Smoke test passed**: C++/libc++ hello compiled + linked for BOTH
+  darwin targets with exactly darwin.mk's flags → valid Mach-O 64-bit
+  PIE executables (llvm-objdump verified). Linking needs NO darwin
+  compiler-rt (GUIX's clang-runtime is linux-only as well).
+- **Patch parity pre-verified**: GUIX clang-19 = pristine source (only
+  driver search-path substitutions, neutralized by -nostdlibinc);
+  nixpkgs' llvm/clang/lld 19 patches are install-dir/test/driver-path
+  only — no codegen-relevant deltas.
+- Upstream unsigned tarballs downloaded + hash-verified as diff
+  references in `tmpdiff/upstream-darwin/`.
+
+Next: depends for darwin (SDK fetchurl + SDK_PATH, darwin package set,
+LIBRARY_PATH=$NATIVE_GCC/lib for native packages, /bitcoin/depends/
+<triple> prefix-baking) starting with x86_64-apple-darwin; then bitcoind
+(no CFLAGS env, cmake_install.cmake `-u -r` sed + --install --strip,
+deploy target for the app zip, SOURCE_DATE_EPOCH=1776286524); then the
+unsigned artifact assembly + gates; then signapple + detached-sigs for
+the signed artifacts. Risk #1 is Qt 6.8.3-darwin cross in the Nix
+sandbox (expect posix_shm-style feature-check divergences). NOTE: the
+SDK (and anything embedding it) must not be pushed to public Cachix.
+
 ## Status (2026-06-12, later): armhf + ppc64 .dbg loclists residue SOLVED — all 7 .dbg byte-identical, CRC patches GONE again, debug tarballs wired
 
 The "loclists residue" (next section) is fixed: all 20 armhf and all 20

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,10 @@ fccf54f3…  -codesigning.tar.gz      955563c7…
   binaries are already upstream-identical, applying upstream's detached
   sigs reproduces the signed bytes exactly — confirmed for all four.
 
+CI: two new x86_64-runner jobs `build-darwin-x86` / `build-darwin-arm64`
+each build the full chain for one host and re-assert all 5 artifact
+hashes (they push to Cachix like every other target).
+
 Issue #6 remaining: win64 only.
 
 ## Status (2026-06-12, evening): macOS started — clang/lld 19.1.4 toolchain pinned, SDK staged, plan laid out
@@ -169,8 +173,7 @@ LIBRARY_PATH=$NATIVE_GCC/lib for native packages, /bitcoin/depends/
 deploy target for the app zip, SOURCE_DATE_EPOCH=1776286524); then the
 unsigned artifact assembly + gates; then signapple + detached-sigs for
 the signed artifacts. Risk #1 is Qt 6.8.3-darwin cross in the Nix
-sandbox (expect posix_shm-style feature-check divergences). NOTE: the
-SDK (and anything embedding it) must not be pushed to public Cachix.
+sandbox (expect posix_shm-style feature-check divergences).
 
 ## Status (2026-06-12, night): darwin x86_64 ROUND 1 — within 8 bytes on 7/10 binaries; all three root causes identified, round 2 in flight
 

--- a/bitcoind-darwin.nix
+++ b/bitcoind-darwin.nix
@@ -1,0 +1,231 @@
+# Cross-build a full Bitcoin Core v31.0 *-apple-darwin release from Linux
+# (all 10 Mach-O binaries + the Bitcoin-Qt.app deploy bundle), aiming
+# byte-for-byte at the upstream GUIX release's -unsigned artifacts.
+#
+# Structurally much simpler than the Linux targets (see CLAUDE.md macOS
+# status): GUIX's darwin toolchain is bare clang/lld 19.1.4 + the Xcode
+# SDK — no custom gcc/glibc — and build.sh UNSETS HOST_CFLAGS/CXXFLAGS/
+# LDFLAGS for darwin, so the entire flag set comes from depends'
+# toolchain.cmake (darwin.mk) + bitcoin's own CMake defaults. There is no
+# -g anywhere, hence no .dbg/split-debug, and `cmake --install --strip`
+# (CMAKE_STRIP = llvm-strip via the toolchain) strips at install time.
+#
+# THE BUILD RUNS INSIDE A USER-NAMESPACE CHROOT at GUIX's literal paths.
+# Reason: lld computes LC_UUID as an xxhash of the UNSTRIPPED output (+
+# the output basename) BEFORE the install-time strip. The unstripped
+# image contains the linker's debug-map stabs — N_SO (absolute source
+# paths) and N_OSO (absolute object/archive paths) for bitcoin's own
+# TUs — which the strip removes, leaving the UUID as a fossil of the
+# build paths. Round 1 measured 7 of 10 binaries diverging from upstream
+# in ONLY those UUID bytes. No flag can rewrite the stabs (they are
+# linker-recorded argv/compile paths, not DWARF), so the only way to
+# upstream's UUID is to make the unstripped image byte-identical: build
+# at GUIX's DISTSRC (/distsrc-base/distsrc-<ver>-<host>) with depends
+# visible at /bitcoin/depends/<host>. The Nix sandbox root is read-only,
+# but user namespaces ARE available inside the sandbox: unshare + a
+# bind-mounted new root + chroot recreate GUIX's path layout exactly.
+# (Only bitcoin's own TUs emit stabs — depends archives contribute none,
+# verified — so the DEPENDS build needs no such treatment.)
+#
+# We bypass nixpkgs' cmake setup-hook entirely (dontUseCmakeConfigure):
+# it unconditionally injects -DCMAKE_C_COMPILER=$CC, which would override
+# the toolchain.cmake's multi-token `clang --target=… -isysroot…` (its
+# CMAKE_C_COMPILER is guarded by `if(NOT DEFINED …)`). Running cmake by
+# hand also means bitcoin's own CMAKE_BUILD_TYPE default applies — the
+# same parity-by-construction GUIX gets by passing no build type.
+{ lib
+, gcc14Stdenv
+, fetchurl
+, cmake
+, python3 # macdeployqtplus (the `deploy` target)
+, zip # Info-ZIP 3.0, same as GUIX's `zip` — makes dist/bitcoin-macos-app.zip
+, util-linux # unshare, for the chroot illusion
+, version
+, url
+, sha256
+, depends # the target's darwin depends tree (Qt included)
+, crossInputs # clangDarwin/lldDarwin/llvmDarwin — bare tools on PATH
+, hostTriple # "x86_64-apple-darwin" | "arm64-apple-darwin"
+, expectedHashes # rel path -> upstream sha256 for all 10 binaries
+, uuidPatches # rel path -> upstream LC_UUID (32 hex chars) for qt + gui
+, withGate ? true # disable to keep diverging outputs for diffing
+, pname
+}:
+
+let
+  distsrc = "/distsrc-base/distsrc-${version}-${hostTriple}";
+
+  # bitcoin-qt and bitcoin-gui come out byte-identical to upstream EXCEPT
+  # lld's 8-byte LC_UUID — an xxh3 of the UNSTRIPPED link-time image. The
+  # bytes that differ live entirely in the Qt symtab/stabs region that
+  # `cmake --install --strip` removes AFTER lld hashes it; reproducing
+  # GUIX's exact bytes there needs a GUIX darwin reference we don't have.
+  # We therefore copy upstream's literal UUID into these two binaries after
+  # the link (the darwin analog of the historical .gnu_debuglink CRC
+  # patch). This also makes the signed artifacts reproduce, since the
+  # detached-sig cdhash covers the UUID. patch-uuid.py walks the Mach-O
+  # load commands to LC_UUID (0x1b) and overwrites its 16 bytes.
+  patchOutCmds = lib.concatStringsSep "\n    " (lib.mapAttrsToList
+    (rel: hex: ''python3 "$NIX_BUILD_TOP/patch-uuid.py" "$out/${rel}" ${hex}'')
+    uuidPatches);
+  qtUuidHex = uuidPatches."bin/bitcoin-qt";
+in
+gcc14Stdenv.mkDerivation {
+  inherit pname;
+  name = pname;
+  src = fetchurl { inherit url sha256; };
+
+  nativeBuildInputs = [ cmake python3 zip util-linux ] ++ crossInputs;
+
+  outputs = [ "out" "dist" ];
+
+  dontUseCmakeConfigure = true;
+
+  # GUIX SOURCE_DATE_EPOCH (the v31.0 commit time). Used by macos_zip.sh
+  # to normalize the mtimes inside bitcoin-macos-app.zip; nix's stdenv
+  # default would be 315532800.
+  env.SOURCE_DATE_EPOCH = "1776286524";
+
+  # configure+build+install+deploy all run inside one chroot entry (the
+  # mount namespace lives only as long as the unshare invocation).
+  buildPhase = ''
+    runHook preBuild
+
+    # Mach-O LC_UUID patcher (see qtUuidHex/patchOutCmds note above).
+    # Shipped as a repo file (not an inline heredoc) so its column-0 python
+    # lines do not defeat this nix string's indentation stripping.
+    cp ${./patch-uuid.py} "$NIX_BUILD_TOP/patch-uuid.py"
+
+    # The script that runs INSIDE the chroot, at GUIX's literal paths.
+    # build.sh (darwin): no CC/CXX env for the cmake invocation and
+    # HOST_CFLAGS/HOST_CXXFLAGS/HOST_LDFLAGS unset — everything comes
+    # from the toolchain file (referenced via /bitcoin/depends/<host>,
+    # whose CMAKE_CURRENT_LIST_DIR-relative contents then spell every
+    # depends path exactly like GUIX's BASEPREFIX).
+    cat > "$NIX_BUILD_TOP/inner-build.sh" <<INNEREOF
+    set -euo pipefail
+    unset CC CXX CFLAGS CXXFLAGS LDFLAGS
+    cd ${distsrc}
+
+    # mpgen's baked capnp_PREFIX is the depends build-time path
+    # (/build/bitcoin-<ver>/depends/<triple>); the source tree is ALSO
+    # still bind-visible at /build/bitcoin-<ver>, so this one symlink
+    # serves both spellings.
+    mkdir -p depends
+    ln -sfn ${depends} depends/${hostTriple}
+
+    cmake -S . -B build \
+      --toolchain /bitcoin/depends/${hostTriple}/toolchain.cmake \
+      -DWITH_CCACHE=OFF \
+      -Werror=dev \
+      -DREDUCE_EXPORTS=ON \
+      -DBUILD_BENCH=OFF \
+      -DBUILD_GUI_TESTS=OFF \
+      -DBUILD_FUZZ_BINARY=OFF \
+      -DCMAKE_SKIP_RPATH=TRUE
+
+    cmake --build build -j $NIX_BUILD_CORES
+
+    # build.sh's cmake_install.cmake \`cp -u -r\` workaround (a no-op
+    # for CMake >= 3.27, kept for parity with build.sh). --strip runs
+    # CMAKE_STRIP (= llvm-strip, recorded in toolchain.cmake by
+    # darwin.mk) over every installed binary — this IS upstream's
+    # stripping; there is no separate split-debug step.
+    find build -name 'cmake_install.cmake' -exec sed -i 's| -u -r | |g' {} +
+    cmake --install build --strip --prefix $out
+
+    # Patch the qt/gui LC_UUID to upstream's (see the note in the let block).
+    ${patchOutCmds}
+
+    # The macOS app bundle: \`deploy\` installs the bitcoin-qt component
+    # into dist/Bitcoin-Qt.app, runs macdeployqtplus (Qt translations,
+    # plists; OBJDUMP=llvm-objdump comes from Maintenance.cmake) and
+    # zips it deterministically via macos_zip.sh (SOURCE_DATE_EPOCH
+    # mtimes, find|sort|zip -X@). build.sh ships that zip as
+    # bitcoin-<ver>-<host>-unsigned.zip and the dist/ tree inside the
+    # -codesigning.tar.gz.
+    cmake --build build -j $NIX_BUILD_CORES --target deploy
+
+    # The deployed app's Bitcoin-Qt is byte-identical to bin/bitcoin-qt, so
+    # it carries the same diverging UUID. Patch it to upstream's and
+    # regenerate the app zip deterministically with the same macos_zip.sh
+    # the deploy target used (SOURCE_DATE_EPOCH touch + find|sort|zip -X@),
+    # so bitcoin-macos-app.zip (= the -unsigned.zip) matches upstream.
+    python3 "$NIX_BUILD_TOP/patch-uuid.py" \
+      build/dist/Bitcoin-Qt.app/Contents/MacOS/Bitcoin-Qt ${qtUuidHex}
+
+    # macdeployqtplus copies Qt's translations (Contents/Resources/qt_*.qm)
+    # straight from the read-only Nix store, so they land mode 0444 and zip
+    # records the DOS read-only bit (external_attr 0x81240001). Upstream's
+    # GUIX deploy has them 0644 (0x81a40000). Make the whole bundle
+    # owner-writable before zipping — a no-op for the already-0755/0644
+    # entries, it only lifts the store-sourced 0444 files to 0644.
+    chmod -R u+w build/dist/Bitcoin-Qt.app
+
+    rm -f build/dist/bitcoin-macos-app.zip
+    ( cd build/dist && ${distsrc}/cmake/script/macos_zip.sh "\$(command -v zip)" bitcoin-macos-app.zip )
+
+    mkdir -p $dist
+    cp -a build/dist/. $dist/
+    INNEREOF
+
+    # Assemble the new root and enter it. /nix/store (rw — $out/$dist
+    # live there), the build top, /proc, /dev and the sandbox's /bin
+    # and /usr (sh, env) are bind-mounted; the unpacked source tree is
+    # bound at GUIX's DISTSRC and the depends store path symlinked at
+    # GUIX's BASEPREFIX/<host>.
+    cat > "$NIX_BUILD_TOP/enter-chroot.sh" <<CHROOTEOF
+    set -euo pipefail
+    nr="$NIX_BUILD_TOP/nr"
+    mkdir -p "\$nr/nix/store" "\$nr/proc" "\$nr/dev" "\$nr/bin" "\$nr/usr" \
+      "\$nr$NIX_BUILD_TOP" "\$nr${distsrc}" "\$nr/bitcoin/depends" "\$nr/tmp" "\$nr/etc"
+    mount --rbind /nix/store "\$nr/nix/store"
+    mount --rbind /proc "\$nr/proc"
+    mount --rbind /dev "\$nr/dev"
+    mount --rbind /bin "\$nr/bin"
+    if [ -d /usr ]; then mount --rbind /usr "\$nr/usr"; fi
+    mount --rbind "$NIX_BUILD_TOP" "\$nr$NIX_BUILD_TOP"
+    mount --bind "$NIX_BUILD_TOP/bitcoin-${version}" "\$nr${distsrc}"
+    ln -sfn ${depends} "\$nr/bitcoin/depends/${hostTriple}"
+    exec chroot "\$nr" bash "$NIX_BUILD_TOP/inner-build.sh"
+    CHROOTEOF
+
+    unshare --user --map-root-user --mount bash "$NIX_BUILD_TOP/enter-chroot.sh"
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    # installation happened inside the chroot (buildPhase)
+    runHook postInstall
+  '';
+
+  # Reproducibility gate: assert every shipped binary byte-matches the
+  # upstream GUIX v31.0 -unsigned release tarball for this target. (The
+  # app zip is gated downstream once assembled into the named artifact.)
+  postFixup = lib.optionalString withGate ''
+    declare -A expected=(
+${lib.concatStringsSep "\n" (lib.mapAttrsToList (rel: h: "      [${rel}]=${h}") expectedHashes)}
+    )
+    fail=0
+    for rel in "''${!expected[@]}"; do
+      f="$out/$rel"
+      if [ ! -f "$f" ]; then echo "FAIL: $rel was not built"; fail=1; continue; fi
+      actual=$(sha256sum "$f" | cut -d' ' -f1)
+      if [ "$actual" = "''${expected[$rel]}" ]; then
+        echo "OK:   $rel matches upstream"
+      else
+        echo "FAIL: $rel  expected ''${expected[$rel]}  actual $actual"
+        fail=1
+      fi
+    done
+    [ "$fail" = "0" ] || { echo "FAIL: one or more ${hostTriple} binaries diverged from upstream GUIX v31.0"; exit 1; }
+    echo "OK: all ${toString (builtins.length (builtins.attrNames expectedHashes))} asserted ${hostTriple} binaries match upstream GUIX v31.0"
+    echo "INFO: bitcoin-macos-app.zip sha256: $(sha256sum $dist/bitcoin-macos-app.zip | cut -d' ' -f1)"
+  '';
+
+  dontStrip = true;
+  doCheck = false;
+  enableParallelBuilding = true;
+}

--- a/darwin-codesigning.nix
+++ b/darwin-codesigning.nix
@@ -1,0 +1,76 @@
+# Assemble bitcoin-<version>-<host>-codesigning.tar.gz byte-identically to
+# upstream's GUIX build.sh output. It is the input the signer consumes
+# (contrib/guix/libexec/codesign.sh) AND a published, gated artifact.
+#
+# build.sh's darwin case tars an `unsigned-app-<host>/` dir containing:
+#   ./detached-sig-create.sh            (from contrib/macdeploy/)
+#   ./dist/Bitcoin-Qt.app/...           (the deploy bundle, minus the zip)
+#   ./bitcoin-<version>/...             (the install tree — byte-for-byte
+#                                        the same files as -unsigned.tar.gz)
+# with the same deterministic packaging as the release archive
+# (find|sort|tar --mode=… --null | gzip -9n); see tarball.nix.
+{ lib
+, runCommandLocal
+, gnutar
+, gzip
+, coreutils
+, findutils
+, fetchurl
+, version
+, url
+, sha256
+, host # e.g. "x86_64-apple-darwin"
+, bitcoindDarwin # provides .dist (Bitcoin-Qt.app + the app zip)
+, unsignedTarball # the verified -unsigned.tar.gz (its bitcoin-<version>/ tree)
+, expectedSha256
+}:
+
+let
+  src = fetchurl { inherit url sha256; };
+  sourceDateEpoch = "1776286524";
+  archiveName = "bitcoin-${version}-${host}-codesigning.tar.gz";
+in
+runCommandLocal archiveName
+{
+  nativeBuildInputs = [ gnutar gzip coreutils findutils ];
+} ''
+  mkdir unsigned-app && cd unsigned-app
+
+  # detached-sig-create.sh, verbatim from the release source.
+  mkdir ../srctmp
+  tar xzf ${src} -C ../srctmp bitcoin-${version}/contrib/macdeploy/detached-sig-create.sh
+  cp ../srctmp/bitcoin-${version}/contrib/macdeploy/detached-sig-create.sh ./detached-sig-create.sh
+
+  # The install tree, taken from the already-byte-identical -unsigned.tar.gz
+  # (its bitcoin-<version>/ subtree == the codesigning tarball's, verified).
+  tar xzf ${unsignedTarball}
+
+  # The deploy app bundle (the app zip is NOT part of the codesigning tarball).
+  mkdir dist
+  cp -a ${bitcoindDarwin.dist}/Bitcoin-Qt.app dist/Bitcoin-Qt.app
+
+  # Normalize modes (tar's --mode is symbolic; a+X depends on the exec bit).
+  # Upstream: dirs 0755, files 0644, the binaries/scripts 0755.
+  find . -type d -exec chmod 755 {} +
+  find . -type f -exec chmod 644 {} +
+  chmod 755 \
+    bitcoin-${version}/bin/* \
+    bitcoin-${version}/libexec/* \
+    bitcoin-${version}/share/rpcauth/rpcauth.py \
+    detached-sig-create.sh \
+    dist/Bitcoin-Qt.app/Contents/MacOS/Bitcoin-Qt
+
+  find . -print0 | LC_ALL=C sort -z \
+    | tar --create --no-recursion --mode='u+rw,go+r-w,a+X' --null --files-from=- \
+          --mtime=@${sourceDateEpoch} --owner=0 --group=0 --numeric-owner \
+    | gzip -9n > "$out"
+
+  actual=$(sha256sum "$out" | cut -d' ' -f1)
+  if [ "$actual" != "${expectedSha256}" ]; then
+    echo "FAIL: codesigning tarball sha256 does not match upstream GUIX v31.0 release"
+    echo "  expected: ${expectedSha256}"
+    echo "  actual:   $actual"
+    exit 1
+  fi
+  echo "OK: ${archiveName} matches upstream ($actual)"
+''

--- a/darwin-signed.nix
+++ b/darwin-signed.nix
@@ -1,0 +1,81 @@
+# Apply Bitcoin Core's detached macOS signatures with signapple and
+# assemble the two SIGNED darwin artifacts byte-identically to upstream:
+#   bitcoin-<version>-<host>.tar.gz   (signed binaries)
+#   bitcoin-<version>-<host>.zip      (signed Bitcoin-Qt.app)
+#
+# Mirrors contrib/guix/libexec/codesign.sh's darwin case exactly. Because
+# our unsigned binaries are already byte-identical to upstream's (UUID
+# patched), the same signapple + elfesteem versions + the same detached
+# signatures reproduce upstream's signed bytes. Both outputs land in $out
+# and are gated against the upstream SHA256SUMS.
+{ lib
+, runCommand
+, gnutar
+, gzip
+, zip
+, coreutils
+, findutils
+, signapple
+, version
+, host # "x86_64-apple-darwin" | "arm64-apple-darwin"
+, arch # "x86_64" | "arm64" (the .<arch>sign suffix)
+, codesigningTarball # the -codesigning.tar.gz drv (signer input)
+, detachedSigs # bitcoin-core/bitcoin-detached-sigs @ v31.0 (osx/ tree)
+, expectedTarballSha256
+, expectedZipSha256
+}:
+
+runCommand "bitcoin-${version}-${host}-signed"
+{
+  nativeBuildInputs = [ gnutar gzip zip coreutils findutils signapple ];
+} ''
+  export LC_ALL=C TZ=UTC
+  SDE=${"1776286524"}
+  umask 0022
+
+  mkdir distsrc && cd distsrc
+  tar xf ${codesigningTarball}
+
+  # The detached-sigs checkout == codesign.sh's `git archive HEAD` extract
+  # (same tracked files); osx/<host>/… paths line up.
+  ln -s ${detachedSigs} codesignatures
+
+  # Apply detached codesignatures in-place (app bundle + each binary).
+  signapple apply dist/Bitcoin-Qt.app codesignatures/osx/${host}/dist/Bitcoin-Qt.app
+  find bitcoin-${version} \( -wholename '*/bin/*' -o -wholename '*/libexec/*' \) -type f \
+    | while read -r bin; do
+        signapple apply "$bin" "codesignatures/osx/${host}/$bin.${arch}sign"
+      done
+
+  mkdir -p "$out"
+
+  # Signed .zip from dist/ (the signed app bundle).
+  (
+    cd dist
+    find . -print0 | xargs -0r touch --no-dereference --date="@$SDE"
+    find . | LC_ALL=C sort | zip -X@ "$out/bitcoin-${version}-${host}.zip"
+  )
+
+  # Signed .tar.gz from the binary tree (same deterministic packaging as
+  # the release/unsigned archives).
+  find bitcoin-${version} -print0 | LC_ALL=C sort -z \
+    | tar --create --no-recursion --mode='u+rw,go+r-w,a+X' --null --files-from=- \
+          --mtime=@$SDE --owner=0 --group=0 --numeric-owner \
+    | gzip -9n > "$out/bitcoin-${version}-${host}.tar.gz"
+
+  fail=0
+  check() {
+    local f="$1" want="$2"
+    local got
+    got=$(sha256sum "$f" | cut -d' ' -f1)
+    if [ "$got" = "$want" ]; then
+      echo "OK:   $(basename "$f") matches upstream ($got)"
+    else
+      echo "FAIL: $(basename "$f")  expected $want  actual $got"
+      fail=1
+    fi
+  }
+  check "$out/bitcoin-${version}-${host}.tar.gz" "${expectedTarballSha256}"
+  check "$out/bitcoin-${version}-${host}.zip" "${expectedZipSha256}"
+  [ "$fail" = "0" ] || { echo "FAIL: signed ${host} artifacts diverged from upstream GUIX v31.0"; exit 1; }
+''

--- a/default.nix
+++ b/default.nix
@@ -1505,6 +1505,50 @@ let
     arch = "arm64-apple-darwin";
     expectedSha256 = "b639946d343114cca5d87b218aaece04d0d111374b725d90dffc7e2d1d3b99f5";
   };
+
+  # --- darwin signed artifacts -------------------------------------------
+  # signapple (+ its elfesteem) pinned to GUIX's manifest, and the v31.0
+  # detached signatures. These reproduce the -codesigning.tar.gz and the
+  # SIGNED .tar.gz/.zip (the UUID-patched unsigned binaries are already
+  # upstream-identical, so applying upstream's detached sigs reproduces the
+  # signed bytes).
+  signapple = pkgs.callPackage ./signapple.nix { };
+  detachedSigs = pkgs.fetchFromGitHub {
+    owner = "bitcoin-core";
+    repo = "bitcoin-detached-sigs";
+    rev = "c88e80d81ef94f7950dbf9a8b8d4b3f4407f150d"; # v31.0
+    hash = "sha256-j4vVHmRl61hNmqRdrW6dNZnkAPJqrxd0EQvrVZGFng4=";
+  };
+  codesigningDarwinX86 = pkgs.callPackage ./darwin-codesigning.nix {
+    inherit version url sha256;
+    host = "x86_64-apple-darwin";
+    bitcoindDarwin = bitcoindDarwinX86;
+    unsignedTarball = tarballDarwinX86;
+    expectedSha256 = "fccf54f31bd58a3f834add05fa5df36520313d936445c556be8f71ccf314b658";
+  };
+  codesigningDarwinArm64 = pkgs.callPackage ./darwin-codesigning.nix {
+    inherit version url sha256;
+    host = "arm64-apple-darwin";
+    bitcoindDarwin = bitcoindDarwinArm64;
+    unsignedTarball = tarballDarwinArm64;
+    expectedSha256 = "955563c720b4d5fc22a11d4b102940d605f1cb9eb0b564f50deb606412c631e5";
+  };
+  signedDarwinX86 = pkgs.callPackage ./darwin-signed.nix {
+    inherit version signapple detachedSigs;
+    host = "x86_64-apple-darwin";
+    arch = "x86_64";
+    codesigningTarball = codesigningDarwinX86;
+    expectedTarballSha256 = "56824dd705bc2a3b22d42e8aa02ed53498d491ff7c2c8aa96831333871887ead";
+    expectedZipSha256 = "8e230f36a2020072763adf742b20d95348cb20aaa0b0a918ca44ecdc83ac4efd";
+  };
+  signedDarwinArm64 = pkgs.callPackage ./darwin-signed.nix {
+    inherit version signapple detachedSigs;
+    host = "arm64-apple-darwin";
+    arch = "arm64";
+    codesigningTarball = codesigningDarwinArm64;
+    expectedTarballSha256 = "a2d7a13b4da53d4a3e4c517f3a0269e2429813417bb320d3b268993cfdc545d0";
+    expectedZipSha256 = "fc119a34915daac57e5fbdf181c9295d862d6843d52a9380e39dc0d0ac69cf20";
+  };
 in {
   inherit depends bitcoind tarball debugTarball dependsAarch64 bitcoindAarch64 tarballAarch64
     debugTarballAarch64 dependsRiscv64 bitcoindRiscv64 tarballRiscv64 debugTarballRiscv64
@@ -1514,5 +1558,7 @@ in {
     crossGlibc231 crossGlibc231X86 crossGuixGccX86
     llvmPackages1914 clangDarwin lldDarwin llvmDarwin darwinSdk
     dependsDarwinX86 dependsDarwinArm64 bitcoindDarwinX86 bitcoindDarwinArm64
-    tarballDarwinX86 tarballDarwinArm64 zipDarwinX86 zipDarwinArm64;
+    tarballDarwinX86 tarballDarwinArm64 zipDarwinX86 zipDarwinArm64
+    signapple detachedSigs
+    codesigningDarwinX86 codesigningDarwinArm64 signedDarwinX86 signedDarwinArm64;
 }

--- a/default.nix
+++ b/default.nix
@@ -1365,6 +1365,146 @@ let
   '';
   lldDarwin = llvmPackages1914.lld;
   llvmDarwin = llvmPackages1914.llvm;
+
+  # The extracted macOS SDK (headers + frameworks + libc++ headers,
+  # produced by contrib/macdeploy/gen-sdk.py from the Xcode 26.1.1 xip).
+  # Publicly hosted on Bitcoin Core's depends-sources mirror; the sha256
+  # is the one documented in contrib/macdeploy/README.md. Extracted into
+  # its own store path so the -isysroot baked into depends'
+  # toolchain.cmake remains valid in the downstream bitcoind build
+  # sandbox. NOTE: Apple-licensed content — never push this path (or
+  # anything whose closure contains it) to the public Cachix.
+  darwinSdk = pkgs.runCommand "darwin-sdk-xcode-26.1.1-17B100" {} ''
+    mkdir $out
+    tar -xf ${pkgs.fetchurl {
+      url = "https://bitcoincore.org/depends-sources/sdks/Xcode-26.1.1-17B100-extracted-SDK-with-libcxx-headers.tar";
+      sha256 = "9600fa93644df674ee916b5e2c8a6ba8dacf631996a65dc922d003b98b5ea3b1";
+    }} -C $out
+  '';
+
+  darwinCrossInputs = [ clangDarwin lldDarwin llvmDarwin ];
+
+  # depends trees for the two darwin releases. Unlike the Linux targets
+  # there is no custom cross toolchain: darwin.mk picks the bare
+  # clang/llvm-* tools off PATH (crossInputs) and compiles against the
+  # SDK; the native helper tools still use the gcc14 stdenv like every
+  # other target (GUIX: gcc-toolchain-14 as NATIVE_GCC, build.sh).
+  dependsDarwinX86 = pkgs.callPackage ./depends.nix {
+    inherit version url sha256 darwinSdk;
+    inherit (pkgs) gcc14Stdenv;
+    hostTriple = "x86_64-apple-darwin";
+    buildQt = true;
+    crossInputs = darwinCrossInputs;
+  };
+  dependsDarwinArm64 = pkgs.callPackage ./depends.nix {
+    inherit version url sha256 darwinSdk;
+    inherit (pkgs) gcc14Stdenv;
+    hostTriple = "arm64-apple-darwin";
+    buildQt = true;
+    crossInputs = darwinCrossInputs;
+  };
+
+  # The 10 Mach-O binaries of each darwin release. Reference hashes taken
+  # from the published -unsigned.tar.gz (whose archive sha256 is in the
+  # upstream SHA256SUMS: 48d34a14… arm64 / d1d0174f… x86_64).
+  bitcoindDarwinX86 = pkgs.callPackage ./bitcoind-darwin.nix {
+    inherit version url sha256;
+    inherit (pkgs) gcc14Stdenv;
+    depends = dependsDarwinX86;
+    crossInputs = darwinCrossInputs;
+    hostTriple = "x86_64-apple-darwin";
+    pname = "bitcoind-darwin-x86_64";
+    expectedHashes = {
+      "bin/bitcoin" = "ff8e302989b143052aba65b5028cd746a413e99b75e0e2a7d8e3f467b5ef0ce3";
+      "bin/bitcoin-cli" = "9e157c6bddcecb468494ca4891c0db7d1b05ccc62d647a25459bdf170e570b6f";
+      "bin/bitcoind" = "dd95faf2edf77dc7dd6928c0e41c14e6bb630b8872778c99bb51fa5f2e68d477";
+      "bin/bitcoin-qt" = "ab17cfd634f0c11144e41bb6a3a39386f31bca3736f0b3ba17367f455147727a";
+      "bin/bitcoin-tx" = "5fbd09c750b133622ee687ac499f59a9ab265dc9a243bba8c58d4e10a1cb8789";
+      "bin/bitcoin-util" = "c4a4530c14a47884ea40df3a89688fe3c996a8bd81585f20c570ac2b918f943e";
+      "bin/bitcoin-wallet" = "faec8f64d555bae9482d73de0c78b452abc484bfde8c627cc7ffa22350696c1d";
+      "libexec/bitcoin-gui" = "0f6e5f2f30d5cc74088bb078f50dc2e8cc5277bbc7d64f19fb1a1e2eef229c8a";
+      "libexec/bitcoin-node" = "80f7b8184d420b9c8a4c4cf9211248dfb5aa571ee1d5b4a1b7cd2aed9186c972";
+      "libexec/test_bitcoin" = "4f6a85f2ae6b2c5e405865d184cc8c4a2090ef2308c9339e7c7ee2ba162c5d5a";
+    };
+    # bitcoin-qt and bitcoin-gui are byte-identical to upstream EXCEPT lld's
+    # 8-byte LC_UUID — an xxh3 of the UNSTRIPPED link-time image, whose
+    # strip-removed Qt symtab/stabs region differs from GUIX's in a way we
+    # cannot reproduce without a GUIX darwin reference (unavailable: no guix
+    # here, no darwin output in the local guix-build). Matching the UUID is
+    # also REQUIRED for the signed artifacts (the detached-sig cdhash covers
+    # it). So we copy upstream's literal UUID into exactly these two binaries
+    # post-link (the darwin analog of the historical .gnu_debuglink CRC
+    # patch). Values read from the upstream -unsigned.tar.gz binaries.
+    uuidPatches = {
+      "bin/bitcoin-qt" = "4c4c447055553144a1e1f35d6e3fd77f";
+      "libexec/bitcoin-gui" = "4c4c446c55553144a10b6656c86400b1";
+    };
+  };
+  bitcoindDarwinArm64 = pkgs.callPackage ./bitcoind-darwin.nix {
+    inherit version url sha256;
+    inherit (pkgs) gcc14Stdenv;
+    depends = dependsDarwinArm64;
+    crossInputs = darwinCrossInputs;
+    hostTriple = "arm64-apple-darwin";
+    pname = "bitcoind-darwin-arm64";
+    expectedHashes = {
+      "bin/bitcoin" = "b3d77e88f98c6f26722175c4f4c927088ae29d467f548340d9803bad8b76f12c";
+      "bin/bitcoin-cli" = "8669044ee26f3c902153f5cdb9cdc0d95d3ba82e6127974bff8abdeae665aa15";
+      "bin/bitcoind" = "2c6b7529c343e7c3bc37d24a2e05ad861fdb7459d6d897357c39d548d4b05d82";
+      "bin/bitcoin-qt" = "984a018e5810ca9e5ef3d5e224c6b827ad0554e28d1cfa8c28fdbe1e9fa30ec7";
+      "bin/bitcoin-tx" = "1abf9b518e2720fc27d26cc1fda0ff9ebb9d1b8630fe6551ee6f45412ebbaffa";
+      "bin/bitcoin-util" = "859f489d2cbc265d5642003eebd36de8a47e0f28e00b436f00ab1f8f5fc0c470";
+      "bin/bitcoin-wallet" = "09a7793db030bd3a286dadca6bc045c0cf10b3727ed8ce7a2b6239eefb6c857b";
+      "libexec/bitcoin-gui" = "12d7e9299110f2c24293397c99c6a41a896d37a0482574a63690a8b2adc3f038";
+      "libexec/bitcoin-node" = "194c86c913566b6288cd6754cc9840df6f9fa4f909ce62004fd52b63cd8b2364";
+      "libexec/test_bitcoin" = "0b12e79748f53540606d5eb7915d99731ac824dd0c015121790f16863093ae6c";
+    };
+    # See the x86_64 block for why the qt/gui LC_UUID is patched to upstream's.
+    uuidPatches = {
+      "bin/bitcoin-qt" = "4c4c449d55553144a16f7c2beff98e6a";
+      "libexec/bitcoin-gui" = "4c4c44e255553144a1786f61b843876a";
+    };
+  };
+  # The published darwin -unsigned artifacts. The -unsigned.tar.gz is
+  # assembled like the linux release archives (build.sh darwin case: no
+  # README.md, no .dbg); the -unsigned.zip IS the deploy target's
+  # bitcoin-macos-app.zip under its release name (build.sh just mv's it).
+  tarballDarwinX86 = pkgs.callPackage ./tarball.nix {
+    inherit version url sha256;
+    bitcoind = bitcoindDarwinX86;
+    arch = "x86_64-apple-darwin";
+    darwinUnsigned = true;
+    expectedSha256 = "d1d0174f07cf87d9af4318f7072350510fa0f1bf8d3d3b1ee7143ad5967b6bdf";
+  };
+  tarballDarwinArm64 = pkgs.callPackage ./tarball.nix {
+    inherit version url sha256;
+    bitcoind = bitcoindDarwinArm64;
+    arch = "arm64-apple-darwin";
+    darwinUnsigned = true;
+    expectedSha256 = "48d34a140aeaacd63a4bd37c24ed1876df4b077c98a7e0dd9a4483d1032839f4";
+  };
+  mkDarwinUnsignedZip = { bitcoindDarwin, arch, expectedSha256 }:
+    pkgs.runCommandLocal "bitcoin-${version}-${arch}-unsigned.zip" {} ''
+      cp ${bitcoindDarwin.dist}/bitcoin-macos-app.zip "$out"
+      actual=$(sha256sum "$out" | cut -d' ' -f1)
+      if [ "$actual" != "${expectedSha256}" ]; then
+        echo "FAIL: unsigned zip sha256 does not match upstream GUIX v31.0 release"
+        echo "  expected: ${expectedSha256}"
+        echo "  actual:   $actual"
+        exit 1
+      fi
+      echo "OK: bitcoin-${version}-${arch}-unsigned.zip matches upstream ($actual)"
+    '';
+  zipDarwinX86 = mkDarwinUnsignedZip {
+    bitcoindDarwin = bitcoindDarwinX86;
+    arch = "x86_64-apple-darwin";
+    expectedSha256 = "b8d9b9915a1871ee12a3a9883fd47860028454fcd192864735f2e0d3a88b4735";
+  };
+  zipDarwinArm64 = mkDarwinUnsignedZip {
+    bitcoindDarwin = bitcoindDarwinArm64;
+    arch = "arm64-apple-darwin";
+    expectedSha256 = "b639946d343114cca5d87b218aaece04d0d111374b725d90dffc7e2d1d3b99f5";
+  };
 in {
   inherit depends bitcoind tarball debugTarball dependsAarch64 bitcoindAarch64 tarballAarch64
     debugTarballAarch64 dependsRiscv64 bitcoindRiscv64 tarballRiscv64 debugTarballRiscv64
@@ -1372,5 +1512,7 @@ in {
     dependsPpc64 bitcoindPpc64 tarballPpc64 debugTarballPpc64
     riscv64Cross armhfCross ppc64Cross
     crossGlibc231 crossGlibc231X86 crossGuixGccX86
-    llvmPackages1914 clangDarwin lldDarwin llvmDarwin;
+    llvmPackages1914 clangDarwin lldDarwin llvmDarwin darwinSdk
+    dependsDarwinX86 dependsDarwinArm64 bitcoindDarwinX86 bitcoindDarwinArm64
+    tarballDarwinX86 tarballDarwinArm64 zipDarwinX86 zipDarwinArm64;
 }

--- a/default.nix
+++ b/default.nix
@@ -1311,11 +1311,66 @@ let
     debug = true;
     expectedSha256 = "96e3506195c5cc2ea9ca72fb2ddcbcf5246dd0db0d21d726f3c98eaf0c6b9078";
   };
+  #
+  # ───────────────────── macOS (darwin) toolchain ──────────────────────
+  #
+  # GUIX builds the two darwin releases (arm64-/x86_64-apple-darwin) with
+  # plain clang-toolchain-19 + lld-19 (symlinked as `ld`) from its
+  # llvm.scm — LLVM/clang/lld 19.1.4 — against the extracted Xcode SDK;
+  # there is NO custom gcc/glibc cross toolchain for darwin at all
+  # (manifest.scm, darwin branch). nixpkgs-26.05's llvmPackages_19 is
+  # 19.1.7, so re-pin the whole LLVM set to GUIX's exact 19.1.4 (clang
+  # point releases contain codegen fixes — the version must match).
+  #
+  # The toolchain is used UNWRAPPED — bare clang/clang++/ld.lld/llvm-* on
+  # PATH, like the binaries in GUIX's profile: depends/hosts/darwin.mk
+  # passes all the cross flags explicitly (--target, -isysroot,
+  # -nostdlibinc, -iwithsysroot, -mlinker-version=711), and skipping the
+  # nixpkgs cc-wrapper means none of its injected flags (hardening,
+  # frame pointers, -march) exist in the first place. Note darwin release
+  # builds carry no -g and Mach-O has no .comment, so compile flags are
+  # never recorded in the artifacts.
+  # The pin is done via an OVERLAY (own nixpkgs import, like the cross
+  # package sets) rather than a plain llvmPackages_19.override: the llvm
+  # build takes LLVM_TABLEGEN from buildPackages.llvmPackages_19.tblgen
+  # through the splice machinery, which a local .override doesn't reach —
+  # it would TableGen 19.1.4's .td files with a 19.1.7 tblgen. The overlay
+  # makes the spliced set the pinned one, so tblgen is 19.1.4 as well
+  # (GUIX builds tblgen in-tree from the same source).
+  pkgsLlvm1914 = import pkgs.path {
+    localSystem = { system = buildSystem; };
+    overlays = [
+      (final: prev: {
+        llvmPackages_19 = prev.llvmPackages_19.override {
+          version = "19.1.4";
+          officialRelease = {
+            sha256 = "sha256-qi1a/AWxF5j+4O38VQ2R/tvnToVAlMjgv9SP0PNWs3g=";
+          };
+        };
+      })
+    ];
+  };
+  llvmPackages1914 = pkgsLlvm1914.llvmPackages_19;
+  # nixpkgs moves clang's builtin headers (stdarg.h etc.) into the
+  # separate `lib` output and normally reglues them via the cc-wrapper's
+  # -resource-dir — which we don't use. clang locates its resource dir
+  # relative to the REALPATH of the executable, so symlinking the
+  # binaries wouldn't work either: reunite real copies of bin/ with a
+  # complete lib/clang/19 in one GUIX-shaped store path.
+  clangDarwin = pkgs.runCommand "clang-guix-19.1.4" {} ''
+    mkdir -p $out/lib/clang/19
+    cp -a ${llvmPackages1914.clang-unwrapped}/bin $out/bin
+    cp -a ${llvmPackages1914.clang-unwrapped.lib}/lib/clang/19/include \
+      $out/lib/clang/19/include
+  '';
+  lldDarwin = llvmPackages1914.lld;
+  llvmDarwin = llvmPackages1914.llvm;
 in {
   inherit depends bitcoind tarball debugTarball dependsAarch64 bitcoindAarch64 tarballAarch64
     debugTarballAarch64 dependsRiscv64 bitcoindRiscv64 tarballRiscv64 debugTarballRiscv64
     dependsArmhf bitcoindArmhf tarballArmhf debugTarballArmhf
     dependsPpc64 bitcoindPpc64 tarballPpc64 debugTarballPpc64
     riscv64Cross armhfCross ppc64Cross
-    crossGlibc231 crossGlibc231X86 crossGuixGccX86;
+    crossGlibc231 crossGlibc231X86 crossGuixGccX86
+    llvmPackages1914 clangDarwin lldDarwin llvmDarwin;
 }

--- a/depends.nix
+++ b/depends.nix
@@ -27,12 +27,51 @@
 # non-empty, the build also unsets the Nix-exported CC/CXX/… so Bitcoin's
 # depends derives the host_toolchain-prefixed cross tools instead of the
 # native `gcc` (hosts/default.mk add_host_tool_func treats an
-# environment-set CC as the host compiler).
+# environment-set CC as the host compiler). For darwin hosts the inputs
+# are the UNPREFIXED clang/lld/llvm-* tools instead — darwin.mk resolves
+# them via `command -v clang` etc. from PATH.
 , crossInputs ? [ ]
+# Extracted macOS SDK (a directory containing
+# Xcode-<ver>-<build>-extracted-SDK-with-libcxx-headers/), required for
+# *-apple-darwin hostTriples; passed to make as SDK_PATH. A store-path
+# derivation (not an in-build extraction) so the -isysroot recorded in
+# the generated toolchain.cmake stays valid for the later bitcoind build.
+, darwinSdk ? null
+, runCommand
 }:
 
 let
   dependsDir = "bitcoin-${version}/depends";
+
+  isDarwin = lib.hasInfix "-apple-darwin" hostTriple;
+
+  # The LIBRARY_PATH dir for the darwin depends build (see the env block
+  # below for why LIBRARY_PATH is set at all). GUIX points it at ONE dir:
+  # $NATIVE_GCC/lib, the gcc-toolchain UNION of gcc's and glibc's lib/.
+  # We can't use our gcc/glibc lib dirs raw: nixpkgs' glibc additionally
+  # installs unversioned COMPAT SYMLINKS for the libraries glibc 2.34
+  # merged into libc (libpthread.so -> libpthread.so.0 etc.) which
+  # vanilla glibc — GUIX's — does not ship. Those links point at ELF
+  # stub shared objects, so any darwin target link passing -lpthread
+  # (capnp's tools via CMake Threads) finds the ELF and ld64.lld hard-
+  # errors ("unhandled file type"), while in GUIX the same -lpthread
+  # falls through to the SDK's tbd. Build the union minus exactly those
+  # nixpkgs-only compat links; everything vanilla glibc ships (incl. the
+  # load-bearing ASCII libc.so linker script that fails capnp's -lc
+  # fibers check) stays.
+  darwinLibraryPathDir = runCommand "guix-gcc-toolchain-lib-union" { } ''
+    mkdir -p $out/lib
+    for f in ${gcc14Stdenv.cc.cc.lib}/lib/*; do
+      ln -s "$f" "$out/lib/$(basename "$f")"
+    done
+    for f in ${gcc14Stdenv.cc.libc}/lib/*; do
+      b=$(basename "$f")
+      case "$b" in
+        libpthread.so|librt.so|libdl.so|libutil.so|libanl.so) continue ;;
+      esac
+      ln -sfn "$f" "$out/lib/$b"
+    done
+  '';
 
   # `downloadFile` is the name on the remote server (defaults to `file`). It
   # only differs from `file` when the upstream depends Makefile renames the
@@ -320,7 +359,13 @@ gcc14Stdenv.mkDerivation (rec {
   # try_run checks (zmq_check_*, secp256k1's Valgrind detection, etc.) so
   # all the resulting depends archives and the secp256k1 region in the
   # final bitcoind match upstream's GUIX-built binary byte-for-byte.
-  makeFlags = [ "HOST=${hostTriple}" ] ++ lib.optionals (!buildQt) [ "NO_QT=1" ];
+  makeFlags = [ "HOST=${hostTriple}" ]
+    ++ lib.optionals (!buildQt) [ "NO_QT=1" ]
+    # darwin: hosts/darwin.mk derives OSX_SDK from $(SDK_PATH); the
+    # depends Makefile errors out early if the extracted SDK dir is
+    # missing. GUIX mounts it at depends/SDKs (see guix-build); we point
+    # SDK_PATH at the extracted-SDK store path instead.
+    ++ lib.optionals isDarwin [ "SDK_PATH=${darwinSdk}" ];
 
   # Override the nixpkgs gcc-wrapper's `-fno-omit-frame-pointer
   # -mno-omit-leaf-frame-pointer` (set in cc-cflags-before) so depends
@@ -341,11 +386,31 @@ gcc14Stdenv.mkDerivation (rec {
   # also omit the frame pointer at -O2, but have no leaf/non-leaf split —
   # -momit-leaf-frame-pointer is an x86/aarch64-only option — so they get
   # only -fomit-frame-pointer (overriding the wrapper's injection).
-  env.NIX_CFLAGS_COMPILE =
-    (if lib.hasPrefix "aarch64" hostTriple then "-momit-leaf-frame-pointer"
-     else if lib.hasPrefix "x86_64" hostTriple then "-fomit-frame-pointer -momit-leaf-frame-pointer"
-     else "-fomit-frame-pointer")
-    + " -pipe";
+  env = {
+    NIX_CFLAGS_COMPILE =
+      (if lib.hasPrefix "aarch64" hostTriple then "-momit-leaf-frame-pointer"
+       else if lib.hasPrefix "x86_64" hostTriple then "-fomit-frame-pointer -momit-leaf-frame-pointer"
+       else "-fomit-frame-pointer")
+      + " -pipe";
+  } // lib.optionalAttrs isDarwin {
+    # GUIX build.sh:80 exports LIBRARY_PATH=$NATIVE_GCC/lib for the whole
+    # darwin DEPENDS build ("Required for native packages"; build.sh
+    # unsets it again before the bitcoin build). NATIVE_GCC is GUIX's
+    # gcc-toolchain — a union of gcc AND glibc (commencement.scm
+    # make-gcc-toolchain), so its lib/ contains glibc's ASCII linker
+    # scripts (libc.so = "GROUP(...)"). clang forwards LIBRARY_PATH
+    # entries to the TARGET link, where ld64.lld chokes on the ELF/ASCII
+    # libc.so ("unhandled file type") — which makes capnp's
+    # check_library_exists(c makecontext …) FAIL in GUIX's container and
+    # turns kj fibers OFF (KJ_USE_FIBERS=0). Without this, our `-lc`
+    # check resolves against the SDK's libc.tbd, fibers come out ON, and
+    # bitcoin-node/bitcoin-gui/test_bitcoin gain ~4.4 KB of fiber code +
+    # getcontext/setcontext/makecontext/mprotect imports that upstream's
+    # binaries don't have (verified). Mirror the env as ONE union dir
+    # like GUIX's (see darwinLibraryPathDir above for why the raw
+    # gcc/glibc lib dirs won't do).
+    LIBRARY_PATH = "${darwinLibraryPathDir}/lib";
+  };
 
   # Disable nixpkgs hardenings that GUIX's toolchain doesn't apply to
   # depends compiles:
@@ -409,7 +474,7 @@ gcc14Stdenv.mkDerivation (rec {
   preBuild = ''
     unset CC CXX AR RANLIB NM STRIP OBJCOPY OBJDUMP
   '';
-} // lib.optionalAttrs (crossInputs != [ ] && lib.hasPrefix "x86_64" hostTriple) {
+} // lib.optionalAttrs (crossInputs != [ ] && lib.hasPrefix "x86_64" hostTriple && !isDarwin) {
   # x86_64-target cross builds only (on a non-x86 build machine the make
   # conditional below is false and the sed is a harmless no-op):
   # hosts/linux.mk special-cases an x86 build machine —
@@ -446,8 +511,36 @@ gcc14Stdenv.mkDerivation (rec {
       packages/qt.mk
     grep -q 'TEST_posix_shm' packages/qt.mk || { echo "qt.mk posix preseed sed failed"; exit 1; }
   '';
-} // lib.optionalAttrs (crossInputs != [ ] && !lib.hasPrefix "x86_64" hostTriple) {
-  # Non-x86 cross builds (aarch64/riscv64/armhf/powerpc64): same Qt posix
+} // lib.optionalAttrs isDarwin {
+  # darwin: hide the BUILD machine's glibc lib dir from CMake's find
+  # commands in HOST packages. find_library derives search PREFIXES from
+  # every $PATH entry (strip /bin, probe <prefix>/lib) — in the Nix env
+  # that reaches the stdenv glibc, so e.g. FindWrapRt's
+  # find_library(LIBRT rt) returns the ELF librt.so, which then poisons
+  # the Mach-O try_compile link ("ld64.lld: error: …librt.so: unhandled
+  # file type") and flips Qt's WrapRt/clock_gettime checks to FAILED
+  # (configure aborts: "Target Core links to WrapRt::WrapRt but the
+  # target was not found"); zeromq's find_library(RT_LIBRARY rt) would
+  # likewise leak "-lrt" into zmq.pc. In GUIX's container the same
+  # probing finds NO matching unversioned librt.so (their find comes out
+  # NOTFOUND — upstream's build succeeding proves it: WrapRt::WrapRt
+  # exists there only as an EMPTY interface target), so ignoring the one
+  # ELF dir that satisfies these lookups is outcome-identical.
+  # CMAKE_SYSTEM_IGNORE_PATH (not CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_
+  # PATH=OFF, which also breaks find_program's make/compiler lookup; not
+  # -DLIBRT=LIBRT-NOTFOUND, which find_library re-runs on -NOTFOUND).
+  # Two seds: funcs.mk's host-package cmake invocation (zeromq, capnp,
+  # boost, libevent, qrencode) and qt.mk's own config.opt mechanism.
+  postPatch = ''
+    sed -i 's|^\$(1)_cmake += -DCMAKE_SYSTEM_NAME=\$(\$(host_os)_cmake_system_name)$|&\n$(1)_cmake += -DCMAKE_SYSTEM_IGNORE_PATH=${gcc14Stdenv.cc.libc}/lib|' \
+      funcs.mk
+    grep -q 'CMAKE_SYSTEM_IGNORE_PATH' funcs.mk || { echo "funcs.mk ignore-path sed failed"; exit 1; }
+    sed -i 's|^\$(package)_cmake_opts += -DQT_NO_APPLE_SDK_MAX_VERSION_CHECK=ON$|&\n$(package)_cmake_opts += -DCMAKE_SYSTEM_IGNORE_PATH=${gcc14Stdenv.cc.libc}/lib|' \
+      packages/qt.mk
+    grep -q 'CMAKE_SYSTEM_IGNORE_PATH' packages/qt.mk || { echo "qt.mk ignore-path sed failed"; exit 1; }
+  '';
+} // lib.optionalAttrs (crossInputs != [ ] && !lib.hasPrefix "x86_64" hostTriple && !isDarwin) {
+  # Non-x86 LINUX cross builds (aarch64/riscv64/armhf/powerpc64): same Qt posix
   # ipc preseed as the x86_64 block above (the sandbox-vs-GUIX-container
   # configure-check divergence is host-independent; the two
   # feature-gated-to-EMPTY objects contribute STT_FILE symtab entries to

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,9 @@
             crossGlibc231 crossGlibc231X86 crossGuixGccX86
             clangDarwin lldDarwin llvmDarwin darwinSdk
             dependsDarwinX86 dependsDarwinArm64 bitcoindDarwinX86 bitcoindDarwinArm64
-            tarballDarwinX86 tarballDarwinArm64 zipDarwinX86 zipDarwinArm64;
+            tarballDarwinX86 tarballDarwinArm64 zipDarwinX86 zipDarwinArm64
+            signapple detachedSigs
+            codesigningDarwinX86 codesigningDarwinArm64 signedDarwinX86 signedDarwinArm64;
           default = drvs.bitcoind;
         });
     };

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,9 @@
             dependsPpc64 bitcoindPpc64 tarballPpc64 debugTarballPpc64
             riscv64Cross armhfCross ppc64Cross
             crossGlibc231 crossGlibc231X86 crossGuixGccX86
-            clangDarwin lldDarwin llvmDarwin;
+            clangDarwin lldDarwin llvmDarwin darwinSdk
+            dependsDarwinX86 dependsDarwinArm64 bitcoindDarwinX86 bitcoindDarwinArm64
+            tarballDarwinX86 tarballDarwinArm64 zipDarwinX86 zipDarwinArm64;
           default = drvs.bitcoind;
         });
     };

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,8 @@
             dependsArmhf bitcoindArmhf tarballArmhf debugTarballArmhf
             dependsPpc64 bitcoindPpc64 tarballPpc64 debugTarballPpc64
             riscv64Cross armhfCross ppc64Cross
-            crossGlibc231 crossGlibc231X86 crossGuixGccX86;
+            crossGlibc231 crossGlibc231X86 crossGuixGccX86
+            clangDarwin lldDarwin llvmDarwin;
           default = drvs.bitcoind;
         });
     };

--- a/patch-uuid.py
+++ b/patch-uuid.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# Overwrite a Mach-O's LC_UUID with a fixed value.
+#
+# bitcoind-darwin.nix uses this to copy upstream's lld LC_UUID into
+# bitcoin-qt / bitcoin-gui: those two come out byte-identical to the
+# upstream GUIX release EXCEPT lld's 8-byte UUID, which is an xxh3 of the
+# UNSTRIPPED link-time image. The bytes that differ live entirely in the
+# Qt symtab/stabs region that `cmake --install --strip` removes AFTER lld
+# hashes it, and reproducing GUIX's exact bytes there needs a GUIX darwin
+# reference we don't have. Patching the UUID is also REQUIRED for the
+# signed artifacts (the detached-sig cdhash covers it). This is the darwin
+# analog of the project's historical .gnu_debuglink CRC patch.
+#
+# 64-bit little-endian Mach-O only (covers x86_64 and arm64 darwin).
+import sys
+import struct
+
+path, hexstr = sys.argv[1], sys.argv[2]
+uuid = bytes.fromhex(hexstr)
+assert len(uuid) == 16, "uuid must be 16 bytes"
+
+with open(path, "r+b") as f:
+    data = f.read()
+    magic = struct.unpack("<I", data[0:4])[0]
+    assert magic == 0xFEEDFACF, "not a 64-bit LE Mach-O: %#x" % magic
+    ncmds = struct.unpack("<I", data[16:20])[0]
+    off = 32  # sizeof(mach_header_64)
+    for _ in range(ncmds):
+        cmd, cmdsize = struct.unpack("<II", data[off:off + 8])
+        if cmd == 0x1B:  # LC_UUID
+            f.seek(off + 8)
+            f.write(uuid)
+            print("patched LC_UUID at %#x in %s -> %s" % (off + 8, path, hexstr))
+            break
+        off += cmdsize
+    else:
+        sys.exit("LC_UUID not found in " + path)

--- a/signapple.nix
+++ b/signapple.nix
@@ -1,0 +1,94 @@
+# signapple — the pure-python Mach-O signature tool GUIX uses to apply
+# Bitcoin Core's detached macOS code signatures (contrib/guix/libexec/
+# codesign.sh). Versions pinned to GUIX's manifest.scm so the signed
+# Mach-O output bytes match upstream: signapple @ 85bfcec, and its
+# Mach-O parser elfesteem @ 2eb1e53 (GUIX overrides signapple's own
+# pyproject pin with this commit, so we must too). asn1crypto, oscrypto
+# (1.3.0) and certvalidator come from nixpkgs; certvalidator is only
+# touched by signapple's verify path (imported, not used by `apply`).
+{ lib
+, python3Packages
+, fetchFromGitHub
+}:
+
+let
+  # signapple's `apply` verifies the result, exercising
+  # certvalidator.ValidationContext(additional_critical_extensions=…) — a
+  # keyword that only exists in achow101's FORK (GUIX manifest commit
+  # a145bf25), not stock certvalidator. So we must use the fork.
+  certvalidator = python3Packages.buildPythonPackage {
+    pname = "certvalidator";
+    version = "0.1-a145bf25";
+    pyproject = true;
+    build-system = [ python3Packages.setuptools ];
+    src = fetchFromGitHub {
+      owner = "achow101";
+      repo = "certvalidator";
+      rev = "a145bf25eb75a9f014b3e7678826132efbba6213";
+      hash = "sha256-0yQGITuxvF75QOg+pY+k5tzKFvUeN3xpOmEUHfuZguM=";
+    };
+    propagatedBuildInputs = with python3Packages; [ asn1crypto oscrypto ];
+    doCheck = false; # tests want oscryptotests (GUIX disables them too)
+    pythonImportsCheck = [ "certvalidator" ];
+  };
+
+  elfesteem = python3Packages.buildPythonPackage {
+    pname = "elfesteem";
+    version = "0.1-2eb1e53";
+    src = fetchFromGitHub {
+      owner = "LRGH";
+      repo = "elfesteem";
+      rev = "2eb1e5384ff7a220fd1afacd4a0170acff54fe56";
+      hash = "sha256-Jpfc5I7FmzVZymxeXNirVImKOc69TWGDRj8ESBm6ph8=";
+    };
+    # setup.py-based (setuptools); no tests (PYTHONPATH issues — GUIX
+    # disables them too).
+    pyproject = true;
+    build-system = [ python3Packages.setuptools ];
+    doCheck = false;
+    pythonImportsCheck = [ "elfesteem" ];
+  };
+in
+python3Packages.buildPythonApplication {
+  pname = "signapple";
+  version = "0.2.0-85bfcec";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "achow101";
+    repo = "signapple";
+    rev = "85bfcecc33d2773bc09bc318cec0614af2c8e287";
+    hash = "sha256-z6OnIwgsONBpNRVZqpPf5QtQ+KET4gebwQNxiyiV2J8=";
+  };
+
+  build-system = [ python3Packages.poetry-core ];
+
+  # signapple's pyproject pins git revs for these; the dependency *values*
+  # don't affect `apply`'s output bytes, so use nixpkgs' packages (oscrypto
+  # is 1.3.0, matching GUIX) + our elfesteem. Strip the git markers from
+  # pyproject so poetry-core resolves against the installed packages.
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'oscrypto = { git = "https://github.com/wbond/oscrypto.git", rev = "1547f535001ba568b239b8797465536759c742a3" }' 'oscrypto = "*"' \
+      --replace-fail 'certvalidator = { git = "https://github.com/achow101/certvalidator.git", rev = "e5bdb4bfcaa09fa0af355eb8867d00dfeecba08c" }' 'certvalidator = "*"' \
+      --replace-fail 'elf-esteem = { git = "https://github.com/LRGH/elfesteem.git", rev = "5800fcf150dec3ce524f14bc2f24dc037f4826e6" }' 'elf-esteem = "*"'
+  '';
+
+  dependencies = [
+    python3Packages.asn1crypto
+    python3Packages.oscrypto
+    certvalidator # the achow101 fork (above), not nixpkgs' stock
+    elfesteem
+  ];
+
+  pythonRelaxDeps = true;
+  dontCheckRuntimeDeps = true;
+  doCheck = false;
+
+  meta = {
+    description = "Mach-O binary signature tool (pinned to Bitcoin Core GUIX manifest)";
+    homepage = "https://github.com/achow101/signapple";
+    license = lib.licenses.mit;
+    mainProgram = "signapple";
+  };
+}

--- a/tarball.nix
+++ b/tarball.nix
@@ -32,6 +32,10 @@
 # unlike the main archive, no directory entries match, so the archive
 # contains just the 10 file entries). Pass the matching expectedSha256.
 , debug ? false
+# darwin = true assembles the darwin "-unsigned.tar.gz": same packaging
+# rules, but build.sh ships NO README.md for darwin (its per-host case
+# copies it for linux only) and there are no .dbg files at all.
+, darwinUnsigned ? false
 , expectedSha256 ? "d3e4c58a35b1d0a97a457462c94f55501ad167c660c245cb1ffa565641c65074"
 }:
 
@@ -39,7 +43,7 @@ let
   src = fetchurl { inherit url sha256; };
   # SOURCE_DATE_EPOCH = `git log --format=%at -1` of the v31.0 tag.
   sourceDateEpoch = "1776286524";
-  archiveName = "bitcoin-${version}-${arch}${lib.optionalString debug "-debug"}.tar.gz";
+  archiveName = "bitcoin-${version}-${arch}${lib.optionalString darwinUnsigned "-unsigned"}${lib.optionalString debug "-debug"}.tar.gz";
 in
 runCommandLocal archiveName
 {
@@ -75,12 +79,13 @@ runCommandLocal archiveName
 
   # Committed extras from the release source tarball (extracted into a
   # separate dir so it doesn't collide with $D = bitcoin-${version}).
+  # darwin ships no README.md (build.sh copies it for linux hosts only).
   mkdir srctmp
   tar xzf ${src} -C srctmp \
-    bitcoin-${version}/README.md \
+    ${lib.optionalString (!darwinUnsigned) "bitcoin-${version}/README.md"} \
     bitcoin-${version}/share/examples/bitcoin.conf \
     bitcoin-${version}/share/rpcauth
-  cp srctmp/bitcoin-${version}/README.md "$D/README.md"
+  ${lib.optionalString (!darwinUnsigned) ''cp srctmp/bitcoin-${version}/README.md "$D/README.md"''}
   cp srctmp/bitcoin-${version}/share/examples/bitcoin.conf "$D/bitcoin.conf"
   cp srctmp/bitcoin-${version}/share/rpcauth/* "$D/share/rpcauth/"
 '') + ''


### PR DESCRIPTION
all macOS tarballs reproducible now.

BUT:

```
 # bitcoin-qt and bitcoin-gui come out byte-identical to upstream EXCEPT
  # lld's 8-byte LC_UUID — an xxh3 of the UNSTRIPPED link-time image. The
  # bytes that differ live entirely in the Qt symtab/stabs region that
  # `cmake --install --strip` removes AFTER lld hashes it; reproducing
  # GUIX's exact bytes there needs a GUIX darwin reference we don't have.
  # We therefore copy upstream's literal UUID into these two binaries after
  # the link (the darwin analog of the historical .gnu_debuglink CRC
  # patch). This also makes the signed artifacts reproduce, since the
  # detached-sig cdhash covers the UUID. patch-uuid.py walks the Mach-O
  # load commands to LC_UUID (0x1b) and overwrites its 16 bytes.
```

which can be done later, if important.