### PR TITLE
re-export source archives & make `nix build` build the full .#sha256sum output

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,16 @@ nix build .#sha256sums .#noncodesignedSha256sums --print-build-logs
 
 # diff against the real thing
 curl -sLO https://bitcoincore.org/bin/bitcoin-core-31.0/SHA256SUMS
-grep -v -e bitcoin-31.0.tar.gz -e codesignatures SHA256SUMS \
-  | diff - "$(nix path-info .#sha256sums)"
+diff SHA256SUMS "$(nix path-info .#sha256sums)"
 ```
 
-This builds (or fetches from cache) all 26 artifacts and produces
+This builds (or fetches from cache) all 26 build artifacts plus the two
+`git archive` source tarballs (`bitcoin-31.0.tar.gz` re-exported via
+`fetchurl`, `bitcoin-31.0-codesignatures-31.0.tar.gz` generated from
+`bitcoin-detached-sigs` — both byte-identical to upstream's) and produces
 `all.SHA256SUMS` / `noncodesigned.SHA256SUMS` with bare filenames
-(`<sha256>  <name>`), in the same order as upstream's published files —
-the `diff` above should be empty.
+(`<sha256>  <name>`), in the same order as upstream's published files — the
+`diff` above should be empty.
 
 ### Per-target builds
 

--- a/default.nix
+++ b/default.nix
@@ -39,6 +39,31 @@ let
     hash = "sha256-j4vVHmRl61hNmqRdrW6dNZnkAPJqrxd0EQvrVZGFng4=";
   };
 
+  # The two `git archive` tarballs that round out upstream's SHA256SUMS
+  # alongside the 26 build artifacts above.
+  #
+  # bitcoin-31.0.tar.gz: build.sh's `git archive --prefix=bitcoin-31.0/
+  # HEAD` of the bitcoin/bitcoin repo at the v31.0 tag -- the same tarball
+  # already used as this flake's own source input (`url`/`sha256` above), so
+  # re-exporting it is free.
+  sourceDistArchive = pkgs.fetchurl { inherit url sha256; };
+
+  # bitcoin-31.0-codesignatures-31.0.tar.gz: codesign.sh's
+  # `git archive HEAD` of the bitcoin-detached-sigs repo at the v31.0 tag --
+  # GENERATED from the same repo `detachedSigs` is fetched from (with .git
+  # metadata this time, so `git archive` has a tree+commit to work from). See
+  # nix/lib/codesignatures.nix for how the git-archive + gzip is reproduced
+  # byte-for-byte.
+  detachedSigsGit = pkgs.fetchgit {
+    url = "https://github.com/bitcoin-core/bitcoin-detached-sigs";
+    rev = "c88e80d81ef94f7950dbf9a8b8d4b3f4407f150d"; # v31.0
+    leaveDotGit = true;
+    hash = "sha256-Hv6fEh3PA3MlDjR0TizzoA7ljVOwPYzvjQXm7th6Gis=";
+  };
+  codesignaturesArchive = import ./nix/lib/codesignatures.nix
+    { inherit (pkgs) runCommand gcc git zlib; }
+    { name = "bitcoin-${version}-codesignatures-${version}.tar.gz"; src = detachedSigsGit; };
+
   aarch64 = import ./nix/aarch64-linux-gnu/toolchain.nix { inherit pkgs version url sha256 buildSystem; };
   riscv64 = import ./nix/riscv64-linux-gnu/toolchain.nix { inherit pkgs version url sha256 buildSystem; };
   armhf   = import ./nix/arm-linux-gnueabihf/toolchain.nix { inherit pkgs version url sha256 buildSystem; };
@@ -50,10 +75,9 @@ let
   # The artifacts this project byte-reproduces, in upstream's
   # noncodesigned.SHA256SUMS / all.SHA256SUMS format (see
   # nix/lib/sha256sums.nix). Order matches upstream EXACTLY (verified
-  # against https://bitcoincore.org/bin/bitcoin-core-${version}/SHA256SUMS,
-  # minus the two out-of-scope entries below) so the outputs diff cleanly
-  # against the published files. guix-attest sorts each per-host
-  # SHA256SUMS.part fragment by its pre-basename PATH
+  # against https://bitcoincore.org/bin/bitcoin-core-${version}/SHA256SUMS)
+  # so the outputs diff cleanly against the published files. guix-attest
+  # sorts each per-host SHA256SUMS.part fragment by its pre-basename PATH
   # (<outdir_base>/<HOST>/<file>) — the effective order is HOSTS in
   # alphabetical order (aarch64-linux-gnu, arm-linux-gnueabihf,
   # arm64-apple-darwin, powerpc64-linux-gnu, riscv64-linux-gnu,
@@ -61,9 +85,19 @@ let
   # each darwin/win64 host the *signed* artifacts (from a
   # codesigned_outdir_base that sorts before outdir_base) come first, then
   # the noncodesigned ones — both groups alphabetical by filename.
-  # Out of scope: bitcoin-${version}.tar.gz (the source dist-archive, a
-  # fetchurl input not a build output) and
-  # bitcoin-${version}-codesignatures-${version}.tar.gz (not built here).
+  # bitcoin-${version}.tar.gz (the source dist-archive) and
+  # bitcoin-${version}-codesignatures-${version}.tar.gz (the detached-sigs
+  # git archive) round out the two lists as `dist-archive/...` entries
+  # (sourceDistArchive / codesignaturesArchive, defined above) -- the
+  # former re-exported via fetchurl (it's already this flake's own source
+  # input), the latter GENERATED via `git archive` + zlib gzip from
+  # `detachedSigsGit` (nix/lib/codesignatures.nix), since unlike the source
+  # dist-archive it isn't otherwise a project input. Per guix-attest's sort
+  # (LC_ALL=C sort -k2 on the pre-basename relative path
+  # "dist-archive/bitcoin-31.0*.tar.gz"), "dist-archive/" sorts after the
+  # "a*" host groups (aarch64-linux-gnu, arm-linux-gnueabihf,
+  # arm64-apple-darwin[-codesigned]) and before "powerpc64-linux-gnu"; within
+  # the pair, '-' < '.' puts the codesignatures archive first.
   noncodesignedArtifacts = [
     # aarch64-linux-gnu
     aarch64.debugTarballAarch64
@@ -75,6 +109,8 @@ let
     darwin.codesigningDarwinArm64
     darwin.tarballDarwinArm64
     darwin.zipDarwinArm64
+    # dist-archive
+    sourceDistArchive
     # powerpc64-linux-gnu
     ppc64.debugTarballPpc64
     ppc64.tarballPpc64
@@ -112,6 +148,9 @@ let
     darwin.codesigningDarwinArm64
     darwin.tarballDarwinArm64
     darwin.zipDarwinArm64
+    # dist-archive
+    codesignaturesArchive
+    sourceDistArchive
     # powerpc64-linux-gnu
     ppc64.debugTarballPpc64
     ppc64.tarballPpc64
@@ -157,7 +196,7 @@ in {
     dependsDarwinX86 dependsDarwinArm64 bitcoindDarwinX86 bitcoindDarwinArm64
     tarballDarwinX86 tarballDarwinArm64 zipDarwinX86 zipDarwinArm64
     signapple codesigningDarwinX86 codesigningDarwinArm64 signedDarwinX86 signedDarwinArm64;
-  inherit detachedSigs;
+  inherit detachedSigs sourceDistArchive codesignaturesArchive;
   inherit (win64) mingwGuixGcc mingwGuixGccNoFp mingwBinutils241 pkgsCrossMingw dependsMingw
     mingwCrtStdenv mingwCrt
     bitcoindMingw bitcoindMingwNoGate unsignedZipMingw debugZipMingw

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
             clangDarwin lldDarwin llvmDarwin darwinSdk
             dependsDarwinX86 dependsDarwinArm64 bitcoindDarwinX86 bitcoindDarwinArm64
             tarballDarwinX86 tarballDarwinArm64 zipDarwinX86 zipDarwinArm64
-            signapple detachedSigs
+            signapple detachedSigs sourceDistArchive codesignaturesArchive
             codesigningDarwinX86 codesigningDarwinArm64 signedDarwinX86 signedDarwinArm64
             mingwGuixGcc mingwGuixGccNoFp mingwBinutils241 dependsMingw
             mingwCrtStdenv mingwCrt

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
             osslsigncode25 signedMingw
             pkgsCrossMingwNsis nsisCrtBootSet nsisCrtStdenv
             sha256sums noncodesignedSha256sums;
-          default = drvs.bitcoind;
+          default = drvs.sha256sums;
         });
     };
 }

--- a/nix/lib/codesignatures.nix
+++ b/nix/lib/codesignatures.nix
@@ -1,0 +1,31 @@
+# Reproduce bitcoin-<version>-codesignatures-<version>.tar.gz byte-for-byte:
+# contrib/guix/libexec/codesign.sh's
+#   git -C "$DETACHED_SIGS_REPO" archive --output="$CODESIGNATURE_GIT_ARCHIVE" HEAD
+# (a plain `git archive`, no --prefix; the filename's version comes from
+# `git describe --exact-match HEAD` with the leading 'v' stripped, i.e. the
+# v31.0 tag -> "31.0").
+#
+# `git archive --format=tar HEAD` is independent of the git version used --
+# the tar format, the default tar.umask=0002 mode adjustment, and the
+# commit-date mtimes are all stable across git versions (verified
+# byte-identical to the tar embedded in upstream's published archive,
+# regardless of git version). Only the gzip step is version-sensitive:
+# `git archive --output=*.tar.gz` gzip-compresses via zlib's gzFile API, and
+# GNU gzip's own bundled deflate / zlib-ng both produce DIFFERENT bytes than
+# plain zlib for the same input. nixpkgs' zlib 1.3.2 reproduces GUIX's
+# zlib 1.3 output exactly (verified byte-for-byte against the published
+# artifact) via gzip6.c.
+{ runCommand, gcc, git, zlib }:
+{ name, src }:
+runCommand name
+{
+  nativeBuildInputs = [ gcc git ];
+} ''
+  cp -r ${src} ./repo
+  cd repo
+  git archive --format=tar HEAD > ../archive.tar
+  cd ..
+
+  $CC -O2 ${./gzip6.c} -I${zlib.dev}/include -L${zlib}/lib -lz -Wl,-rpath,${zlib}/lib -o gzip6
+  ./gzip6 archive.tar "$out"
+''

--- a/nix/lib/gzip6.c
+++ b/nix/lib/gzip6.c
@@ -1,0 +1,38 @@
+/* Minimal `gzip -6` via zlib's high-level gzFile API.
+ *
+ * gzopen(path, "wb6") -> deflateInit2(level=6, Z_DEFLATED, MAX_WBITS+16,
+ * DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY) -- i.e. zlib's defaults for a gzip-
+ * wrapped stream at level 6. This is exactly what `git archive
+ * --output=*.tar.gz` does internally, and its output is sensitive to the
+ * zlib version (GNU gzip's own bundled deflate and zlib-ng both produce
+ * different bytes for the same input). */
+#include <zlib.h>
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+    if (argc != 3) {
+        fprintf(stderr, "usage: %s <in> <out.gz>\n", argv[0]);
+        return 1;
+    }
+    FILE *in = fopen(argv[1], "rb");
+    if (!in) { perror(argv[1]); return 1; }
+    gzFile out = gzopen(argv[2], "wb6");
+    if (!out) { perror(argv[2]); return 1; }
+
+    char buf[1 << 16];
+    size_t n;
+    while ((n = fread(buf, 1, sizeof(buf), in)) > 0) {
+        if (gzwrite(out, buf, (unsigned)n) == 0) {
+            fprintf(stderr, "gzwrite failed\n");
+            return 1;
+        }
+    }
+    if (ferror(in)) { perror(argv[1]); return 1; }
+    fclose(in);
+
+    if (gzclose(out) != Z_OK) {
+        fprintf(stderr, "gzclose failed\n");
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
This re-exports the source as `bitcoin-31.0.tar.gz` and the code signatures as `bitcoin-31.0-codesignatures-31.0.tar.gz`. Additionally, `nix build` now builds the whole thing. 